### PR TITLE
[CIAS30-3504] Redirect user to 2FA after accepting T&C

### DIFF
--- a/app/global/reducers/auth/reducer.js
+++ b/app/global/reducers/auth/reducer.js
@@ -317,7 +317,6 @@ export const authReducer = (state = initialState, { type, payload }) =>
       case TERMS_ACCEPT_ERROR:
         draft.loaders.termsAcceptLoading = false;
         draft.errors.termsAcceptError = payload.error;
-        draft.cache.password = null;
         break;
       case CLEAR_ERRORS:
         draft.errors.loginError = null;

--- a/app/global/reducers/auth/sagas/acceptTerms.js
+++ b/app/global/reducers/auth/sagas/acceptTerms.js
@@ -6,7 +6,7 @@ import objectKeysToSnakeCase from 'utils/objectToSnakeCase';
 import { formatMessage } from 'utils/intlOutsideReact';
 
 import { TERMS_ACCEPT_REQUEST, TERMS_ACCEPT_SUCCESS } from '../constants';
-import { termsAcceptSuccess, termsAcceptError } from '../actions';
+import { termsAcceptSuccess, termsAcceptError, loginRequest } from '../actions';
 import messages from '../messages';
 import { makeSelectCachePassword } from '../selectors';
 
@@ -22,6 +22,7 @@ export function* termsAccept({ payload: { fields, onSuccess } }) {
     yield call(toast.success, formatMessage(messages.termsAcceptSuccess), {
       toastId: TERMS_ACCEPT_SUCCESS,
     });
+    yield put(loginRequest(fields.email, password));
     yield put(termsAcceptSuccess());
   } catch {
     yield put(termsAcceptError());


### PR DESCRIPTION
## Related tasks
- [CIAS-3504](https://htdevelopers.atlassian.net/browse/CIAS30-3504)

## What's new?
- Try to log in user automatically after accepting T&C - it will show verification code step for users who reset password after being invited

## Tests
- [ ] Snapshot
- [ ] Logic
- [ ] Integration

# Screenshots


https://github.com/Michigan-State-University/cias-web/assets/86963976/28576c25-2a08-48b8-a993-b8f95b727c1f


