### PR TITLE
[CIAS30-3424] Disable HF screen edit when not in edit mode

### DIFF
--- a/app/containers/Sessions/components/QuestionData/HenryFordQuestion/index.tsx
+++ b/app/containers/Sessions/components/QuestionData/HenryFordQuestion/index.tsx
@@ -14,7 +14,6 @@ import {
 } from 'global/reducers/questions';
 import globalMessages from 'global/i18n/globalMessages';
 import { hfhValueValidator, numericValidator } from 'utils/validators';
-import { canEdit } from 'models/Status/statusPermissions';
 import { RootState } from 'global/reducers';
 import { HenryFordQuestionDTO } from 'models/Question';
 import { themeColors, colors } from 'theme';
@@ -42,7 +41,7 @@ const INPUT_PADDING = 15;
 
 type Props = CommonQuestionProps;
 
-const HenryFordQuestion = ({ isNarratorTab, interventionStatus }: Props) => {
+const HenryFordQuestion = ({ isNarratorTab, editingPossible }: Props) => {
   const { formatMessage } = useIntl();
 
   const selectedQuestion = useSelector<RootState, HenryFordQuestionDTO>(
@@ -79,7 +78,6 @@ const HenryFordQuestion = ({ isNarratorTab, interventionStatus }: Props) => {
 
   const { data } = selectedQuestion.body;
 
-  const editingPossible = canEdit(interventionStatus);
   const isNarratorTabOrEditNotPossible = isNarratorTab || !editingPossible;
 
   const handleMouseEnter = (index: number) => () => {


### PR DESCRIPTION
## Related tasks
- [CIAS-3424](https://htdevelopers.atlassian.net/browse/CIAS30-3424)

## What's new?
- as title

## Tests
- [ ] Snapshot
- [ ] Logic
- [ ] Integration

# Screenshots

<img width="632" alt="image" src="https://github.com/Michigan-State-University/cias-web/assets/86963976/514db284-7887-4186-a3de-7df25ef83900">
