### PR TITLE
[CIAS30-3517] Allow inviting participants without editing enabled

### DIFF
--- a/app/containers/InterventionDetailsPage/index.js
+++ b/app/containers/InterventionDetailsPage/index.js
@@ -182,8 +182,7 @@ export function InterventionDetailsPage({
       testsLeft / catMhPool <= CAT_MH_TEST_COUNT_WARNING_THRESHOLD);
 
   const showSessionCreateButton = canEdit(status);
-  const sharingPossible =
-    canCurrentUserMakeChanges && canShareWithParticipants(status);
+  const sharingPossible = canShareWithParticipants(status);
   const archivingPossible = canCurrentUserMakeChanges && canArchive(status);
 
   const [translateModalVisible, setTranslateModalVisible] = useState(false);

--- a/app/containers/ShareBox/Components/UserList.js
+++ b/app/containers/ShareBox/Components/UserList.js
@@ -12,7 +12,7 @@ import userAvatar from 'assets/svg/user.svg';
 import { colors, fontSizes, themeColors } from 'theme';
 import isNullOrUndefined from 'utils/isNullOrUndefined';
 
-import { HoverableRow, StyledTextButton } from '../styled';
+import { StyledTextButton } from '../styled';
 
 const UserList = ({ users, buttons, buttonIsClose, userWithLoading }) => {
   const getActionButtons = (email, id) => {
@@ -47,7 +47,7 @@ const UserList = ({ users, buttons, buttonIsClose, userWithLoading }) => {
   return (
     <Column data-cy="user-list" data-private>
       {uniqueUsers.map(({ email, id }, index) => (
-        <HoverableRow
+        <Row
           data-cy={`user-list-item-${index}`}
           key={`el-user-${email}`}
           align="center"
@@ -70,7 +70,7 @@ const UserList = ({ users, buttons, buttonIsClose, userWithLoading }) => {
           {!buttonIsClose &&
             !isNullOrUndefined(id) &&
             getActionButtons(email, id)}
-        </HoverableRow>
+        </Row>
       ))}
     </Column>
   );

--- a/app/containers/ShareBox/NormalShareBox.tsx
+++ b/app/containers/ShareBox/NormalShareBox.tsx
@@ -50,7 +50,7 @@ const Component = ({
   const buttons = [
     {
       action: resendInvite,
-      disabled: sharingPossible,
+      disabled: !sharingPossible,
       text: <FormattedMessage {...messages.resend} />,
     },
   ];

--- a/app/containers/ShareBox/OrganizationShareBox.js
+++ b/app/containers/ShareBox/OrganizationShareBox.js
@@ -89,7 +89,7 @@ const OrganizationShareBox = ({
   const buttons = [
     {
       action: handleResend,
-      disabled: sharingPossible,
+      disabled: !sharingPossible,
       text: <FormattedMessage {...messages.resend} />,
     },
   ];

--- a/app/containers/ShareBox/styled.js
+++ b/app/containers/ShareBox/styled.js
@@ -2,20 +2,10 @@ import styled from 'styled-components';
 
 import { colors } from 'theme';
 
-import Row from 'components/Row';
 import TextButton from 'components/Button/TextButton';
 
 export const StyledTextButton = styled(TextButton)`
-  display: none;
   margin-left: 20px;
-`;
-
-export const HoverableRow = styled(Row)`
-  &:hover {
-    ${StyledTextButton} {
-      display: block;
-    }
-  }
 `;
 
 export const SessionIndex = styled.div`

--- a/app/containers/ShareBox/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/ShareBox/tests/__snapshots__/index.test.js.snap
@@ -610,7 +610,7 @@ exports[`<ShareBox /> Should render and match the snapshot 1`] = `
         data-private="true"
       >
         <div
-          class="c27 "
+          class="c27"
           data-cy="user-list-item-0"
         >
           <div


### PR DESCRIPTION
## Related tasks
- [CIAS-3517](https://htdevelopers.atlassian.net/browse/CIAS30-3517)

## What's new?
- as title + fix "Resend email" button being always disabled + always show this button, not on hover only

## Tests
- [x] Snapshot
- [ ] Logic
- [ ] Integration

# Screenshots
<img width="806" alt="image" src="https://github.com/Michigan-State-University/cias-web/assets/86963976/9c9e70e0-3e7b-457b-bbd8-30ef385957ca">

