### PR TITLE
[CIAS30-3520] Use native date input in approvable input

### DIFF
--- a/app/components/Input/ApprovableInput.js
+++ b/app/components/Input/ApprovableInput.js
@@ -217,8 +217,7 @@ const ApprovableInput = ({
             selected={value}
             onChange={(date) => onCheck(date)}
             onFocus={onFocus}
-            placeholderText={placeholder ?? 'MM-DD-YYYY'}
-            dateFormat="MM-dd-yyyy"
+            dateFormat="yyyy-MM-dd"
             selectsEnd={selectsEnd}
             selectsStart={selectsStart}
             startDate={startDate}
@@ -235,6 +234,8 @@ const ApprovableInput = ({
                 width={width}
                 {...styles}
                 ref={ref}
+                keyboard="date"
+                hideNativeDatepicker
               />
             }
             showMonthDropdown

--- a/app/components/Input/index.js
+++ b/app/components/Input/index.js
@@ -80,6 +80,13 @@ const Input = styled.input.attrs((props) => {
       /* Firefox */
       -moz-appearance: textfield;
     `};
+  ${({ hideNativeDatepicker }) =>
+    hideNativeDatepicker &&
+    css`
+      &::-webkit-calendar-picker-indicator {
+        display: none;
+      }
+    `};
   ${margin};
   ${layout};
   ${padding};
@@ -94,7 +101,15 @@ const Input = styled.input.attrs((props) => {
 
 Input.propTypes = {
   transparent: PropTypes.bool,
-  keyboard: PropTypes.oneOf(['text', 'email', 'password', 'number', 'tel']),
+  keyboard: PropTypes.oneOf([
+    'text',
+    'email',
+    'password',
+    'number',
+    'number',
+    'tel',
+    'date',
+  ]),
 };
 
 Input.defaultProps = {

--- a/app/components/Input/tests/__snapshots__/index.test.js.snap
+++ b/app/components/Input/tests/__snapshots__/index.test.js.snap
@@ -24,6 +24,10 @@ exports[`<ApprovableInput /> Should render and match the snapshot as date input 
   border-color: #107969;
 }
 
+.c4::-webkit-calendar-picker-indicator {
+  display: none;
+}
+
 .c4:disabled {
   color: #ABBBD1;
 }
@@ -130,13 +134,11 @@ exports[`<ApprovableInput /> Should render and match the snapshot as date input 
             class="react-datepicker__input-container"
           >
             <input
-              aria-label="Placeholder"
               class="c4"
               color="#2F3850"
               font-size="14"
               height="50"
-              placeholder="Placeholder"
-              type="text"
+              type="date"
               value=""
               width="250"
             />

--- a/app/containers/AnswerSessionPage/components/tests/__snapshots__/CurrencyQuestion.test.js.snap
+++ b/app/containers/AnswerSessionPage/components/tests/__snapshots__/CurrencyQuestion.test.js.snap
@@ -59,6 +59,10 @@ exports[`<CurrencyQuestion /> Should render and match the snapshot 1`] = `
   border-color: #107969;
 }
 
+.c6::-webkit-calendar-picker-indicator {
+  display: none;
+}
+
 .c6:disabled {
   color: #ABBBD1;
 }
@@ -159,13 +163,11 @@ exports[`<CurrencyQuestion /> Should render and match the snapshot 1`] = `
                 class="react-datepicker__input-container"
               >
                 <input
-                  aria-label="MM-DD-YYYY"
                   class="c6"
                   color="#2F3850"
                   font-size="15"
                   height="50"
-                  placeholder="MM-DD-YYYY"
-                  type="text"
+                  type="date"
                   value=""
                   width="200"
                 />

--- a/app/containers/AnswerSessionPage/components/tests/__snapshots__/DateQuestion.test.js.snap
+++ b/app/containers/AnswerSessionPage/components/tests/__snapshots__/DateQuestion.test.js.snap
@@ -59,6 +59,10 @@ exports[`<DateQuestion /> Should render and match the snapshot 1`] = `
   border-color: #107969;
 }
 
+.c6::-webkit-calendar-picker-indicator {
+  display: none;
+}
+
 .c6:disabled {
   color: #ABBBD1;
 }
@@ -159,13 +163,11 @@ exports[`<DateQuestion /> Should render and match the snapshot 1`] = `
                 class="react-datepicker__input-container"
               >
                 <input
-                  aria-label="MM-DD-YYYY"
                   class="c6"
                   color="#2F3850"
                   font-size="15"
                   height="50"
-                  placeholder="MM-DD-YYYY"
-                  type="text"
+                  type="date"
                   value=""
                   width="200"
                 />

--- a/app/containers/InterventionDetailsPage/components/SessionSchedule/tests/__snapshots__/exactDate.test.js.snap
+++ b/app/containers/InterventionDetailsPage/components/SessionSchedule/tests/__snapshots__/exactDate.test.js.snap
@@ -225,6 +225,10 @@ exports[`<SessionSchedule /> Should render and match the snapshot 1`] = `
   border-color: #107969;
 }
 
+.c16::-webkit-calendar-picker-indicator {
+  display: none;
+}
+
 .c16:disabled {
   color: #ABBBD1;
 }
@@ -379,14 +383,12 @@ exports[`<SessionSchedule /> Should render and match the snapshot 1`] = `
                       class="react-datepicker__input-container"
                     >
                       <input
-                        aria-label="MM-DD-YYYY"
                         class="c16"
                         color="#2F3850"
                         font-size="15"
                         height="50"
-                        placeholder="MM-DD-YYYY"
-                        type="text"
-                        value="12-24-2018"
+                        type="date"
+                        value="2018-12-24"
                         width="120"
                       />
                     </div>

--- a/app/containers/Sessions/components/QuestionData/DateQuestion/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/Sessions/components/QuestionData/DateQuestion/tests/__snapshots__/index.test.js.snap
@@ -71,6 +71,10 @@ exports[`<DateQuestion /> Should render and match the snapshot 1`] = `
   border-color: #107969;
 }
 
+.c7::-webkit-calendar-picker-indicator {
+  display: none;
+}
+
 .c7:disabled {
   color: #ABBBD1;
 }
@@ -189,14 +193,12 @@ exports[`<DateQuestion /> Should render and match the snapshot 1`] = `
                 class="react-datepicker__input-container"
               >
                 <input
-                  aria-label="MM-DD-YYYY"
                   class="c7"
                   color="#ABBBD1"
                   disabled=""
                   font-size="15"
                   height="50"
-                  placeholder="MM-DD-YYYY"
-                  type="text"
+                  type="date"
                   value=""
                   width="200"
                 />

--- a/app/containers/Sessions/containers/TextMessagesPage/components/TextMessageScheduling/index.js
+++ b/app/containers/Sessions/containers/TextMessagesPage/components/TextMessageScheduling/index.js
@@ -172,7 +172,7 @@ const TextMessageScheduling = ({
                   fontSize={15}
                   padding={5}
                   textAlign="center"
-                  width={120}
+                  width={150}
                   minDate={new Date()}
                   disabled={disabled || disableDatePicker}
                 />


### PR DESCRIPTION
## Related tasks
- [CIAS-3520](https://htdevelopers.atlassian.net/browse/CIAS30-3520)

## What's new?
-  as title


## Tests
- [X] Snapshot
- [ ] Logic
- [ ] Integration

# Screenshots
## Now date format depends on computer region settings. 

### US

<img width="476" alt="image" src="https://github.com/Michigan-State-University/cias-web/assets/86963976/ec5fb0f8-87ac-43a3-b9e4-93146943008c">

results in

<img width="507" alt="image" src="https://github.com/Michigan-State-University/cias-web/assets/86963976/a5ffb1d8-7dd8-462b-953f-79e3235a3b32">


### Poland

<img width="479" alt="image" src="https://github.com/Michigan-State-University/cias-web/assets/86963976/30877180-d104-45e9-9f2b-43aa244c5819">

results in 

<img width="500" alt="image" src="https://github.com/Michigan-State-University/cias-web/assets/86963976/78c165f2-423a-414b-b809-e09df8426e76">

