### PR TITLE
[CIAS30-3409] Add warnings for duplicating report template internally

### DIFF
--- a/app/components/SelectModal/index.ts
+++ b/app/components/SelectModal/index.ts
@@ -1,2 +1,3 @@
 export * from './useSelectModal';
 export * from './types';
+export * from './constants';

--- a/app/containers/Sessions/containers/ReportTemplatesPage/components/ReportTemplateDetails/DuplicatedReportTemplateWarning.tsx
+++ b/app/containers/Sessions/containers/ReportTemplatesPage/components/ReportTemplateDetails/DuplicatedReportTemplateWarning.tsx
@@ -1,15 +1,53 @@
-import { colors } from 'theme';
+import React, { FC } from 'react';
+import { useIntl } from 'react-intl';
+import { colors, themeColors } from 'theme';
+import { Markup } from 'interweave';
+
+import WarningIcon from 'assets/svg/warning-circle.svg';
+
+import globalMessages from 'global/i18n/globalMessages';
 
 import Row from 'components/Row';
+import Icon from 'components/Icon';
+import Column from 'components/Column';
+import Text from 'components/Text';
+import { TextButton } from 'components/Button';
 
-export const DuplicatedReportTemplateWarning = () => (
-  <Row
-    mb={24}
-    borderRadius="8px"
-    background={colors.chardonnay}
-    py={12}
-    px={16}
-  >
-    TODO add content
-  </Row>
-);
+import messages from '../../messages';
+
+export type Props = {
+  onClose: () => void;
+};
+
+export const DuplicatedReportTemplateWarning: FC<Props> = ({ onClose }) => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <Row
+      mb={24}
+      borderRadius="8px"
+      background={colors.chardonnay}
+      py={12}
+      px={16}
+      gap={16}
+      justify="between"
+    >
+      <Row gap={12} align="center">
+        <Icon src={WarningIcon} stroke={themeColors.text} />
+        <Column>
+          <Text fontSize={15} lineHeight={1.3}>
+            <Markup
+              noWrap
+              content={formatMessage(messages.duplicatedReportTemplateWarning)}
+            />
+          </Text>
+        </Column>
+      </Row>
+      <Row flexShrink={0}>
+        <TextButton onClick={onClose}>
+          {formatMessage(globalMessages.close)}
+        </TextButton>
+      </Row>
+    </Row>
+  );
+};

--- a/app/containers/Sessions/containers/ReportTemplatesPage/components/ReportTemplateDetails/DuplicatedReportTemplateWarning.tsx
+++ b/app/containers/Sessions/containers/ReportTemplatesPage/components/ReportTemplateDetails/DuplicatedReportTemplateWarning.tsx
@@ -1,0 +1,13 @@
+import { colors } from 'theme';
+
+import Row from 'components/Row';
+
+export const DuplicatedReportTemplateWarning = () => (
+  <Row
+    mb={24}
+    borderRadius="8px"
+    background={colors.chardonnay}
+    py={12}
+    px={16}
+  ></Row>
+);

--- a/app/containers/Sessions/containers/ReportTemplatesPage/components/ReportTemplateDetails/DuplicatedReportTemplateWarning.tsx
+++ b/app/containers/Sessions/containers/ReportTemplatesPage/components/ReportTemplateDetails/DuplicatedReportTemplateWarning.tsx
@@ -14,10 +14,10 @@ import { TextButton } from 'components/Button';
 import messages from '../../messages';
 
 export type Props = {
-  onClose: () => void;
+  onDismiss: () => void;
 };
 
-export const DuplicatedReportTemplateWarning: FC<Props> = ({ onClose }) => {
+export const DuplicatedReportTemplateWarning: FC<Props> = ({ onDismiss }) => {
   const { formatMessage } = useIntl();
 
   return (
@@ -38,7 +38,7 @@ export const DuplicatedReportTemplateWarning: FC<Props> = ({ onClose }) => {
         </Text>
       </Row>
       <Row flexShrink={0}>
-        <TextButton onClick={onClose}>
+        <TextButton onClick={onDismiss}>
           {formatMessage(globalMessages.dontShowAgain)}
         </TextButton>
       </Row>

--- a/app/containers/Sessions/containers/ReportTemplatesPage/components/ReportTemplateDetails/DuplicatedReportTemplateWarning.tsx
+++ b/app/containers/Sessions/containers/ReportTemplatesPage/components/ReportTemplateDetails/DuplicatedReportTemplateWarning.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react';
 import { useIntl } from 'react-intl';
 import { colors, themeColors } from 'theme';
-import { Markup } from 'interweave';
 
 import WarningIcon from 'assets/svg/warning-circle.svg';
 
@@ -9,7 +8,6 @@ import globalMessages from 'global/i18n/globalMessages';
 
 import Row from 'components/Row';
 import Icon from 'components/Icon';
-import Column from 'components/Column';
 import Text from 'components/Text';
 import { TextButton } from 'components/Button';
 
@@ -31,21 +29,17 @@ export const DuplicatedReportTemplateWarning: FC<Props> = ({ onClose }) => {
       px={16}
       gap={16}
       justify="between"
+      flexWrap="wrap"
     >
-      <Row gap={12} align="center">
+      <Row gap={12} align="center" flexWrap="wrap">
         <Icon src={WarningIcon} stroke={themeColors.text} />
-        <Column>
-          <Text fontSize={15} lineHeight={1.3}>
-            <Markup
-              noWrap
-              content={formatMessage(messages.duplicatedReportTemplateWarning)}
-            />
-          </Text>
-        </Column>
+        <Text fontSize={15} lineHeight={1.3} maxWidth={290}>
+          {formatMessage(messages.duplicatedReportTemplateWarning)}
+        </Text>
       </Row>
       <Row flexShrink={0}>
         <TextButton onClick={onClose}>
-          {formatMessage(globalMessages.close)}
+          {formatMessage(globalMessages.dontShowAgain)}
         </TextButton>
       </Row>
     </Row>

--- a/app/containers/Sessions/containers/ReportTemplatesPage/components/ReportTemplateDetails/DuplicatedReportTemplateWarning.tsx
+++ b/app/containers/Sessions/containers/ReportTemplatesPage/components/ReportTemplateDetails/DuplicatedReportTemplateWarning.tsx
@@ -9,5 +9,7 @@ export const DuplicatedReportTemplateWarning = () => (
     background={colors.chardonnay}
     py={12}
     px={16}
-  ></Row>
+  >
+    TODO add content
+  </Row>
 );

--- a/app/containers/Sessions/containers/ReportTemplatesPage/components/ReportTemplateDetails/ReportTemplateMainSettings.js
+++ b/app/containers/Sessions/containers/ReportTemplatesPage/components/ReportTemplateDetails/ReportTemplateMainSettings.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
@@ -6,6 +6,9 @@ import { Row, Container } from 'react-grid-system';
 import { FormattedMessage, injectIntl, IntlShape } from 'react-intl';
 
 import { colors, themeColors } from 'theme';
+
+import globalMessages from 'global/i18n/globalMessages';
+
 import {
   deleteReportTemplateLogoRequest,
   deleteReportTemplateRequest,
@@ -34,7 +37,7 @@ import Img from 'components/Img';
 import FlexRow from 'components/Row';
 import { ModalType, useModal } from 'components/Modal';
 import { HelpIconTooltip } from 'components/HelpIconTooltip';
-import { useSelectModal } from 'components/SelectModal';
+import { useSelectModal, SELECT_MODAL_WIDTH } from 'components/SelectModal';
 import CopyModal from 'components/CopyModal';
 import { VIEWS } from 'components/CopyModal/Components';
 
@@ -119,6 +122,28 @@ const ReportTemplateMainSettings = ({
     },
   });
 
+  const duplicateInternallyConfirmationModalProps = useMemo(
+    () => ({
+      description: formatMessage(messages.duplicateInternallyConfirmationTitle),
+      content: formatMessage(messages.duplicateInternallyConfirmationContent),
+      confirmationButtonText: formatMessage(globalMessages.iUnderstand),
+      confirmationButtonColor: 'primary',
+      confirmAction: () => setDuplicateInternallyModalVisible(true),
+      hideCancelButton: true,
+      icon: 'info',
+      width: SELECT_MODAL_WIDTH,
+    }),
+    [setDuplicateInternallyModalVisible],
+  );
+
+  const {
+    openModal: openDuplicateInternallyConfirmationModal,
+    Modal: DuplicateInternallyConfirmationModal,
+  } = useModal({
+    type: ModalType.ConfirmationModal,
+    props: duplicateInternallyConfirmationModalProps,
+  });
+
   const handleDuplicateModalClose = (optionId) => {
     if (!optionId) return;
 
@@ -128,7 +153,7 @@ const ReportTemplateMainSettings = ({
         break;
       }
       case DuplicateReportTemplateOptionId.DUPLICATE_INTERNALLY: {
-        setDuplicateInternallyModalVisible(true);
+        openDuplicateInternallyConfirmationModal(true);
         break;
       }
       default: {
@@ -143,15 +168,16 @@ const ReportTemplateMainSettings = ({
       handleDuplicateModalClose,
     );
 
-  const duplicateModalOptions = useRef(
-    createDuplicateModalOptions(formatMessage, canEdit),
+  const duplicateModalOptions = useMemo(
+    () => createDuplicateModalOptions(formatMessage, canEdit),
+    [canEdit],
   );
 
   const onDuplicate = (event) => {
     event.preventDefault();
     event.stopPropagation();
 
-    openDuplicateModal(duplicateModalOptions.current);
+    openDuplicateModal(duplicateModalOptions);
   };
 
   const handleDuplicateInternallySessionSelected = (targetSession) => {
@@ -168,6 +194,7 @@ const ReportTemplateMainSettings = ({
     <Container style={{ maxWidth: 600 }}>
       <DeleteModal />
       <DuplicateModal />
+      <DuplicateInternallyConfirmationModal />
       <CopyModal
         visible={duplicateInternallyModalVisible}
         onClose={() => setDuplicateInternallyModalVisible(false)}

--- a/app/containers/Sessions/containers/ReportTemplatesPage/components/ReportTemplateDetails/TemplateSectionSettings.js
+++ b/app/containers/Sessions/containers/ReportTemplatesPage/components/ReportTemplateDetails/TemplateSectionSettings.js
@@ -52,6 +52,11 @@ const TemplateSectionSettings = ({
     } else setCurrentlyOpenedCollapsable(variantId);
   };
 
+  const [warningDismissed, setWarningDismissed] = useState(false);
+  useEffect(() => {
+    setWarningDismissed(false);
+  }, [selectedReportId]);
+
   useEffect(() => {
     if (!updateReportTemplateLoading) {
       setIsAddingSection(false);
@@ -128,9 +133,12 @@ const TemplateSectionSettings = ({
             </TextButton>
           </Col>
         </Row>
-        {singleReportTemplate.isDuplicatedFromOtherSession && (
-          <DuplicatedReportTemplateWarning />
-        )}
+        {singleReportTemplate.isDuplicatedFromOtherSession &&
+          !warningDismissed && (
+            <DuplicatedReportTemplateWarning
+              onClose={() => setWarningDismissed(true)}
+            />
+          )}
         <Row>
           <Col>
             <SectionFormula formula={selectedTemplateSection.formula} />

--- a/app/containers/Sessions/containers/ReportTemplatesPage/components/ReportTemplateDetails/TemplateSectionSettings.js
+++ b/app/containers/Sessions/containers/ReportTemplatesPage/components/ReportTemplateDetails/TemplateSectionSettings.js
@@ -27,6 +27,7 @@ import SectionCaseItem from './SectionCaseItem';
 import { Spacer, CardBox } from '../../styled';
 import { ReportTemplatesContext } from '../../utils';
 import messages from '../../messages';
+import { DuplicatedReportTemplateWarning } from './DuplicatedReportTemplateWarning';
 
 const TemplateSectionSettings = ({
   intl: { formatMessage },
@@ -40,6 +41,7 @@ const TemplateSectionSettings = ({
     selectedTemplateSection,
     loaders: { updateReportTemplateLoading },
     canEdit,
+    singleReportTemplate,
   } = useContext(ReportTemplatesContext);
 
   const [currentlyOpenedCollapsable, setCurrentlyOpenedCollapsable] =
@@ -126,6 +128,9 @@ const TemplateSectionSettings = ({
             </TextButton>
           </Col>
         </Row>
+        {singleReportTemplate.isDuplicatedFromOtherSession && (
+          <DuplicatedReportTemplateWarning />
+        )}
         <Row>
           <Col>
             <SectionFormula formula={selectedTemplateSection.formula} />

--- a/app/containers/Sessions/containers/ReportTemplatesPage/components/ReportTemplateDetails/TemplateSectionSettings.js
+++ b/app/containers/Sessions/containers/ReportTemplatesPage/components/ReportTemplateDetails/TemplateSectionSettings.js
@@ -10,6 +10,7 @@ import {
   addSectionCaseRequest,
   deleteTemplateSectionRequest,
   reorderSectionCasesRequest,
+  updateReportTemplateRequest,
 } from 'global/reducers/reportTemplates';
 import { SectionCaseBuilder } from 'models/ReportTemplate';
 
@@ -31,6 +32,7 @@ import { DuplicatedReportTemplateWarning } from './DuplicatedReportTemplateWarni
 
 const TemplateSectionSettings = ({
   intl: { formatMessage },
+  updateReportTemplate,
   addCase,
   deleteSection,
   reorderSectionCases,
@@ -41,6 +43,7 @@ const TemplateSectionSettings = ({
     selectedTemplateSection,
     loaders: { updateReportTemplateLoading },
     canEdit,
+    sessionId,
     singleReportTemplate,
   } = useContext(ReportTemplatesContext);
 
@@ -51,11 +54,6 @@ const TemplateSectionSettings = ({
       setCurrentlyOpenedCollapsable(null);
     } else setCurrentlyOpenedCollapsable(variantId);
   };
-
-  const [warningDismissed, setWarningDismissed] = useState(false);
-  useEffect(() => {
-    setWarningDismissed(false);
-  }, [selectedReportId]);
 
   useEffect(() => {
     if (!updateReportTemplateLoading) {
@@ -82,6 +80,13 @@ const TemplateSectionSettings = ({
   const onDelete = () => {
     setIsDeletingSection(true);
     deleteSection(selectedTemplateSectionId, selectedReportId);
+  };
+
+  const dismissWarning = () => {
+    updateReportTemplate(sessionId, {
+      ...singleReportTemplate,
+      duplicatedFromOtherSessionWarningDismissed: true,
+    });
   };
 
   const { openModal: openDeleteModal, Modal: DeleteModal } = useModal({
@@ -134,10 +139,8 @@ const TemplateSectionSettings = ({
           </Col>
         </Row>
         {singleReportTemplate.isDuplicatedFromOtherSession &&
-          !warningDismissed && (
-            <DuplicatedReportTemplateWarning
-              onClose={() => setWarningDismissed(true)}
-            />
+          !singleReportTemplate.duplicatedFromOtherSessionWarningDismissed && (
+            <DuplicatedReportTemplateWarning onDismiss={dismissWarning} />
           )}
         <Row>
           <Col>
@@ -182,6 +185,7 @@ const TemplateSectionSettings = ({
 };
 
 const mapDispatchToProps = {
+  updateReportTemplate: updateReportTemplateRequest,
   addCase: addSectionCaseRequest,
   deleteSection: deleteTemplateSectionRequest,
   reorderSectionCases: reorderSectionCasesRequest,
@@ -190,6 +194,7 @@ const mapDispatchToProps = {
 const withConnect = connect(null, mapDispatchToProps);
 
 TemplateSectionSettings.propTypes = {
+  updateReportTemplate: PropTypes.func,
   addCase: PropTypes.func,
   deleteSection: PropTypes.func,
   reorderSectionCases: PropTypes.func,

--- a/app/containers/Sessions/containers/ReportTemplatesPage/messages.js
+++ b/app/containers/Sessions/containers/ReportTemplatesPage/messages.js
@@ -187,7 +187,7 @@ export default defineMessages({
   duplicatedReportTemplateWarning: {
     id: `${scope}.duplicatedReportTemplateWarning`,
     defaultMessage:
-      'This report was duplicated from another session.<br/>Make sure all variables are valid.',
+      'This report was duplicated from another session. Make sure all variables are valid.',
   },
   duplicateModalTitle: {
     id: `${scope}.duplicateModalTitle`,

--- a/app/containers/Sessions/containers/ReportTemplatesPage/messages.js
+++ b/app/containers/Sessions/containers/ReportTemplatesPage/messages.js
@@ -214,4 +214,13 @@ export default defineMessages({
     id: `${scope}.duplicateToSelectedSession`,
     defaultMessage: 'Duplicate to selected session',
   },
+  duplicateInternallyConfirmationTitle: {
+    id: `${scope}.duplicateInternallyConfirmationTitle`,
+    defaultMessage: 'Duplicate internally',
+  },
+  duplicateInternallyConfirmationContent: {
+    id: `${scope}.duplicateInternallyConfirmationContent`,
+    defaultMessage:
+      'You are duplicating this report template to another session. Make sure all variables are valid in the duplicated template.',
+  },
 });

--- a/app/containers/Sessions/containers/ReportTemplatesPage/messages.js
+++ b/app/containers/Sessions/containers/ReportTemplatesPage/messages.js
@@ -184,6 +184,11 @@ export default defineMessages({
     defaultMessage:
       'Are you sure you want to delete this Case? It will not be possible to recover it later.',
   },
+  duplicatedReportTemplateWarning: {
+    id: `${scope}.duplicatedReportTemplateWarning`,
+    defaultMessage:
+      'This report was duplicated from another session.<br/>Make sure all variables are valid.',
+  },
   duplicateModalTitle: {
     id: `${scope}.duplicateModalTitle`,
     defaultMessage: 'Duplicate report template',

--- a/app/global/i18n/globalMessages.js
+++ b/app/global/i18n/globalMessages.js
@@ -422,9 +422,9 @@ export default defineMessages({
     id: `${scope}.lastCsvDate`,
     defaultMessage: 'CSV last generated at: ',
   },
-  close: {
-    id: `${scope}.close`,
-    defaultMessage: 'Close',
+  dontShowAgain: {
+    id: `${scope}.dontShowAgain`,
+    defaultMessage: `Don't show again`,
   },
   iUnderstand: {
     id: `${scope}.iUnderstand`,

--- a/app/global/i18n/globalMessages.js
+++ b/app/global/i18n/globalMessages.js
@@ -362,7 +362,7 @@ export default defineMessages({
   },
   questionRequired: {
     id: `${scope}.questionRequired`,
-    defaultMessage: `Required fields are marked with an asterisk<span style='color:${themeColors.warning};'>*</span>`,
+    defaultMessage: `Required fields are marked with an asterisk<span style="color:${themeColors.warning};">*</span>`,
   },
   dragHandle: {
     id: `${scope}.dragHandle`,
@@ -421,5 +421,9 @@ export default defineMessages({
   lastCsvDate: {
     id: `${scope}.lastCsvDate`,
     defaultMessage: 'CSV last generated at: ',
+  },
+  close: {
+    id: `${scope}.close`,
+    defaultMessage: 'Close',
   },
 });

--- a/app/global/i18n/globalMessages.js
+++ b/app/global/i18n/globalMessages.js
@@ -426,4 +426,8 @@ export default defineMessages({
     id: `${scope}.close`,
     defaultMessage: 'Close',
   },
+  iUnderstand: {
+    id: `${scope}.iUnderstand`,
+    defaultMessage: 'I understand',
+  },
 });

--- a/app/models/ReportTemplate/ReportTemplate.ts
+++ b/app/models/ReportTemplate/ReportTemplate.ts
@@ -44,4 +44,5 @@ export interface ReportTemplate {
   originalText: ReportTemplateOriginalText;
   sections: ReportTemplateSection[];
   variants: ReportTemplateVariant[];
+  isDuplicatedFromOtherSession: boolean;
 }

--- a/app/models/ReportTemplate/ReportTemplate.ts
+++ b/app/models/ReportTemplate/ReportTemplate.ts
@@ -45,4 +45,5 @@ export interface ReportTemplate {
   sections: ReportTemplateSection[];
   variants: ReportTemplateVariant[];
   isDuplicatedFromOtherSession: boolean;
+  duplicatedFromOtherSessionWarningDismissed: boolean;
 }

--- a/app/theme/colors.js
+++ b/app/theme/colors.js
@@ -95,6 +95,7 @@ const colors = {
   azureishWhite: '#D4DFF7',
   stormGrey: '#707688',
   logan: '#9BA1B4',
+  chardonnay: '#FFC179',
 };
 
 const themeColors = {


### PR DESCRIPTION
## Related tasks
- [CIAS-3409](https://htdevelopers.atlassian.net/browse/CIAS30-3409)

## What's new?
- add information modal before selecting target session
- add warning in the duplicate after duplicating internally report 

## Tests
- [ ] Snapshot
- [ ] Logic
- [ ] Integration

# Screenshots


https://github.com/Michigan-State-University/cias-web/assets/86963976/d393b18e-194c-450e-8e37-16c7d76785b2


