### PR TITLE
[CIAS30-3589] Restrict available fax recipients' country codes

### DIFF
--- a/app/components/FormikPhoneNumberInput/FormikPhoneNumberInput.tsx
+++ b/app/components/FormikPhoneNumberInput/FormikPhoneNumberInput.tsx
@@ -5,6 +5,8 @@ import { getCountryCallingCode } from 'libphonenumber-js';
 import { FlagIcon } from 'react-flag-kit';
 import { MessageDescriptor, useIntl } from 'react-intl';
 import { NamedProps } from 'react-select';
+import { CountryCode } from 'libphonenumber-js/types';
+import { FlagIconCode } from 'react-flag-kit/typings/FlagIcon';
 
 import FormikNumberInput from 'components/FormikNumberInput';
 import FormikSelect from 'components/FormikSelect';
@@ -15,8 +17,6 @@ import { SelectOption } from 'components/Select/types';
 
 import getCountriesCodes from 'utils/getCountriesCodes';
 
-import { CountryCode } from 'libphonenumber-js/types';
-import { FlagIconCode } from 'react-flag-kit/typings/FlagIcon';
 import messages from './messages';
 import { POPULAR_COUNTRY_CODES } from './constants';
 
@@ -30,6 +30,7 @@ export type Props = {
   prefixInputProps?: object;
   numberInputProps?: object;
   submitOnChange?: boolean;
+  isoOptions?: CountryCode[];
 };
 
 export const FormikPhoneNumberInput: FC<Props> = ({
@@ -42,6 +43,7 @@ export const FormikPhoneNumberInput: FC<Props> = ({
   prefixInputProps,
   numberInputProps,
   submitOnChange,
+  isoOptions,
 }) => {
   const { formatMessage } = useIntl();
 
@@ -63,12 +65,14 @@ export const FormikPhoneNumberInput: FC<Props> = ({
 
   const prefixOptions = useMemo(
     () =>
-      union(POPULAR_COUNTRY_CODES, getCountriesCodes()).map((country) => ({
-        value: country,
-        label: country,
-        filterData: `${country} +${getCountryCallingCode(country)}`,
-      })),
-    [],
+      (isoOptions ?? union(POPULAR_COUNTRY_CODES, getCountriesCodes())).map(
+        (country) => ({
+          value: country,
+          label: country,
+          filterData: `${country} +${getCountryCallingCode(country)}`,
+        }),
+      ),
+    [isoOptions],
   );
 
   const filterOption: NamedProps<SelectOption<CountryCode>>['filterOption'] = (

--- a/app/containers/Sessions/components/QuestionData/ThirdPartyQuestion/RecipientsChooser/ManageRecipientsModalContent.tsx
+++ b/app/containers/Sessions/components/QuestionData/ThirdPartyQuestion/RecipientsChooser/ManageRecipientsModalContent.tsx
@@ -25,6 +25,7 @@ import { createRecipientsFormSchema, formatFax } from './utils';
 import {
   ADD_RECIPIENT_BUTTON_PROPS,
   API_PHONE_NUMBER_FORMAT,
+  FAX_RECIPIENTS_COUNTRY_CODES,
   TAB_CONTENT_HEIGHT,
 } from './constants';
 
@@ -179,6 +180,7 @@ export const ManageRecipientsModalContent: ModalContentRenderer<Recipients> = ({
                             prefixLabel={null}
                             phoneLabel={null}
                             phonePlaceholder={messages.enterFax}
+                            isoOptions={FAX_RECIPIENTS_COUNTRY_CODES}
                           />
                           <ImageButton
                             src={RedBin}

--- a/app/containers/Sessions/components/QuestionData/ThirdPartyQuestion/RecipientsChooser/constants.ts
+++ b/app/containers/Sessions/components/QuestionData/ThirdPartyQuestion/RecipientsChooser/constants.ts
@@ -1,4 +1,5 @@
 import { NumberFormat } from 'libphonenumber-js';
+import { CountryCode } from 'libphonenumber-js/types';
 
 import { themeColors } from 'theme';
 
@@ -11,3 +12,31 @@ export const ADD_RECIPIENT_BUTTON_PROPS = {
 };
 
 export const API_PHONE_NUMBER_FORMAT: NumberFormat = 'E.164';
+
+export const FAX_RECIPIENTS_COUNTRY_CODES: CountryCode[] = [
+  'US',
+  'AU',
+  'MX',
+  'HK',
+  'NL',
+  'GB',
+  'JP',
+  'KR',
+  'BE',
+  'DE',
+  'SG',
+  'IL',
+  'CN',
+  'FR',
+  'IT',
+  'TW',
+  'EG',
+  'CH',
+  'PT',
+  'NZ',
+  'BR',
+  'IE',
+  'ES',
+  'AT',
+  'GR',
+];


### PR DESCRIPTION
## Related tasks
- [CIAS-3589](https://htdevelopers.atlassian.net/browse/CIAS30-3589)

## What's new?
- Allow the select recipients from the list of supported countries https://www.mfax.io/international-fax

## Tests
- [ ] Snapshot
- [ ] Logic
- [ ] Integration

# Screenshots


https://github.com/Michigan-State-University/cias-web/assets/86963976/29522101-b216-44d7-b83c-bd61f50d13f8


