### PR TITLE
[CIAS30-3651] Show Go to Dashboard button on answer session page

### DIFF
--- a/app/containers/AnswerSessionPage/components/GoToDashboardButton.tsx
+++ b/app/containers/AnswerSessionPage/components/GoToDashboardButton.tsx
@@ -1,0 +1,35 @@
+import React, { FC, memo } from 'react';
+import { useIntl } from 'react-intl';
+
+import { RoutePath } from 'global/constants';
+
+import { parametrizeRoutePath } from 'utils/router';
+
+import Button from 'components/Button';
+
+import messages from '../messages';
+import { StyledGhostLink } from '../styled';
+
+export type Props = {
+  userInterventionId: string;
+  isDesktop: boolean;
+};
+
+const GoToDashboardButtonComponent: FC<Props> = ({
+  userInterventionId,
+  isDesktop,
+}) => {
+  const { formatMessage } = useIntl();
+
+  const path = parametrizeRoutePath(RoutePath.USER_INTERVENTION, {
+    userInterventionId,
+  });
+
+  return (
+    <StyledGhostLink to={path} isDesktop={isDesktop}>
+      <Button mt={24} title={formatMessage(messages.goToDashboard)} light />
+    </StyledGhostLink>
+  );
+};
+
+export const GoToDashboardButton = memo(GoToDashboardButtonComponent);

--- a/app/containers/AnswerSessionPage/index.js
+++ b/app/containers/AnswerSessionPage/index.js
@@ -116,6 +116,7 @@ import {
 import { ActionButtons } from './components/ActionButtons';
 import AnswerSessionPageFooter from './components/AnswerSessionPageFooter';
 import ScreenBackButton from './components/ScreenBackButton';
+import { GoToDashboardButton } from './components/GoToDashboardButton';
 
 const AnimationRefHelper = ({
   children,
@@ -680,6 +681,11 @@ export function AnswerSessionPage({
     currentQuestion &&
     FULL_SIZE_QUESTIONS.includes(currentQuestion.type);
 
+  const { multipleFillSessionAvailable, userInterventionId } =
+    location.state ?? {};
+  const showGoToDashboardButton =
+    multipleFillSessionAvailable && userInterventionId;
+
   return (
     <Column
       height="100%"
@@ -804,6 +810,12 @@ export function AnswerSessionPage({
                         title={buttonText()}
                         isDesktop={isDesktop}
                       />
+                      {showGoToDashboardButton && (
+                        <GoToDashboardButton
+                          userInterventionId={userInterventionId}
+                          isDesktop={isDesktop}
+                        />
+                      )}
                     </Row>
                     <Box
                       position="absolute"

--- a/app/containers/AnswerSessionPage/messages.js
+++ b/app/containers/AnswerSessionPage/messages.js
@@ -300,4 +300,8 @@ export default defineMessages({
     defaultMessage:
       'Unknown error occurred. Try again or contact the administrator',
   },
+  goToDashboard: {
+    id: `${scope}.goToDashboard`,
+    defaultMessage: 'Go to Dashboard',
+  },
 });

--- a/app/containers/AnswerSessionPage/styled.js
+++ b/app/containers/AnswerSessionPage/styled.js
@@ -4,9 +4,17 @@ import { elements, colors, mediaQuery, themeColors } from 'theme';
 import { sizes, DESKTOP_MODE } from 'utils/previewMode';
 
 import { Button } from 'components/Button';
+import GhostLink from 'components/GhostLink';
 import { additionalBreakpoints } from 'components/Container/containerBreakpoints';
 
 export const StyledButton = styled(Button)`
+  width: ${({ isDesktop }) => (isDesktop ? '40%' : '80%')};
+  ${mediaQuery.mobile`
+    width: 80%;
+  `}
+`;
+
+export const StyledGhostLink = styled(GhostLink)`
   width: ${({ isDesktop }) => (isDesktop ? '40%' : '80%')};
   ${mediaQuery.mobile`
     width: 80%;


### PR DESCRIPTION
## Related tasks
- [CIAS-3651](https://htdevelopers.atlassian.net/browse/CIAS30-3651)

## What's new?
- show Go to Dashboard button when there are multiple fill sessions available and none session is in progress

## Tests
- [ ] Snapshot
- [ ] Logic
- [ ] Integration

# Screenshots

<img width="1072" alt="image" src="https://github.com/Michigan-State-University/cias-web/assets/86963976/bd39b71a-fbff-404b-a450-941e15f144c1">

