### PR TITLE
[CIAS30-3663] Send health clinic id under correct parameter name

### DIFF
--- a/app/global/reducers/userIntervention/sagas/acceptInvitation.ts
+++ b/app/global/reducers/userIntervention/sagas/acceptInvitation.ts
@@ -26,7 +26,7 @@ export function* acceptInvitation({
       },
     } = yield call(axios.post, url, {
       intervention_id: interventionId,
-      clinic_id: clinicId,
+      health_clinic_id: clinicId,
     });
     if (blocked) {
       yield put(push(`/`));


### PR DESCRIPTION
## Related tasks
- [CIAS-3663](https://htdevelopers.atlassian.net/browse/CIAS30-3663)

## What's new?
- When creating a user intervention (accepting intervention invitation), send health clinic id with parameter name `health_clinic_id` instead of `clinic_id`

## Tests
- [ ] Snapshot
- [ ] Logic
- [ ] Integration

# Screenshots
N/A
