### PR TITLE
[CIAS30-3697] Mirror intervention action buttons based on supported intervention language

### DIFF
--- a/app/assets/svg/triangle-back.svg
+++ b/app/assets/svg/triangle-back.svg
@@ -1,3 +1,4 @@
-<svg width="8" height="11" viewBox="0 0 8 11" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M7 1L2 5.5L7 10" stroke="#C866EA" stroke-width="2" stroke-linecap="round"/>
+<svg width="7" height="12" viewBox="0 0 7 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 5.89069L5.46364 1.42699" stroke="#B727EA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1 6.10668L5.46363 10.5703" stroke="#B727EA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/app/assets/svg/triangle-forward.svg
+++ b/app/assets/svg/triangle-forward.svg
@@ -1,0 +1,4 @@
+<svg width="7" height="12" viewBox="0 0 7 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 6.10931L1.53636 10.573" stroke="#B727EA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 5.89332L1.53637 1.42969" stroke="#B727EA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/app/components/BackButton/constants.ts
+++ b/app/components/BackButton/constants.ts
@@ -1,0 +1,1 @@
+export const BACK_BUTTON_GAP = '8px';

--- a/app/components/BackButton/index.tsx
+++ b/app/components/BackButton/index.tsx
@@ -10,6 +10,8 @@ import triangleBack from 'assets/svg/triangle-back.svg';
 
 import { themeColors } from 'theme';
 
+import { LanguageDirection } from 'global/types/locale';
+
 import Img from 'components/Img';
 import Text from 'components/Text';
 import { TextButton } from 'components/Button';
@@ -31,7 +33,9 @@ export type ButtonProps = {
 };
 
 export type Props = (LinkProps | ButtonProps) &
-  Pick<HTMLAttributes<HTMLParagraphElement>, 'className'>;
+  Pick<HTMLAttributes<HTMLParagraphElement>, 'className'> & {
+    direction?: LanguageDirection;
+  };
 
 const BackButton: FC<Props> = ({
   className,
@@ -40,12 +44,19 @@ const BackButton: FC<Props> = ({
   to,
   onClick,
   disabled,
+  direction,
   ...props
 }) => {
   const renderContent = useCallback(
     () => (
       <>
-        <Img src={triangleBack} alt="traingle" mr={8} mb={2} />
+        <Img
+          src={triangleBack}
+          alt="traingle"
+          mr={8}
+          mb={2}
+          flipHorizontal={direction === LanguageDirection.RTL}
+        />
         <Text
           className={className}
           color={themeColors.secondary}

--- a/app/components/BackButton/index.tsx
+++ b/app/components/BackButton/index.tsx
@@ -29,7 +29,7 @@ export type LinkProps = {
 export type ButtonProps = {
   link?: false;
   to?: string;
-  onClick: () => void;
+  onClick?: () => void;
   disabled?: boolean;
 };
 

--- a/app/components/BackButton/index.tsx
+++ b/app/components/BackButton/index.tsx
@@ -26,7 +26,7 @@ export type LinkProps = {
 };
 
 export type ButtonProps = {
-  link: false;
+  link?: false;
   to?: string;
   onClick: () => void;
   disabled?: boolean;
@@ -71,7 +71,7 @@ const BackButton: FC<Props> = ({
 
   if (link) {
     return (
-      <StyledLink to={to} {...props}>
+      <StyledLink to={to} dir={direction} {...props}>
         {renderContent()}
       </StyledLink>
     );
@@ -84,6 +84,7 @@ const BackButton: FC<Props> = ({
       buttonProps={{
         display: 'flex',
         align: 'center',
+        dir: direction,
         ...props,
       }}
     >

--- a/app/components/BackButton/index.tsx
+++ b/app/components/BackButton/index.tsx
@@ -17,6 +17,7 @@ import Text from 'components/Text';
 import { TextButton } from 'components/Button';
 
 import { StyledLink } from './styled';
+import { BACK_BUTTON_GAP } from './constants';
 
 export type LinkProps = {
   link: true;
@@ -53,8 +54,7 @@ const BackButton: FC<Props> = ({
         <Img
           src={triangleBack}
           alt="traingle"
-          mr={8}
-          mb={2}
+          marginBlockEnd={2}
           flipHorizontal={direction === LanguageDirection.RTL}
         />
         <Text
@@ -85,6 +85,7 @@ const BackButton: FC<Props> = ({
         display: 'flex',
         align: 'center',
         dir: direction,
+        gap: BACK_BUTTON_GAP,
         ...props,
       }}
     >

--- a/app/components/BackButton/styled.js
+++ b/app/components/BackButton/styled.js
@@ -1,9 +1,12 @@
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 
+import { BACK_BUTTON_GAP } from './constants';
+
 export const StyledLink = styled(Link)`
   width: max-content;
   text-decoration: none;
   display: flex;
   align-items: center;
+  gap: ${BACK_BUTTON_GAP};
 `;

--- a/app/components/BackButton/tests/__snapshots__/index.test.js.snap
+++ b/app/components/BackButton/tests/__snapshots__/index.test.js.snap
@@ -4,8 +4,7 @@ exports[`<BackButton /> Should render and match the snapshot 1`] = `
 .c1 {
   width: auto;
   height: auto;
-  margin-bottom: 2px;
-  margin-right: 8px;
+  margin-block-end: 2px;
 }
 
 .c2 {
@@ -31,6 +30,7 @@ exports[`<BackButton /> Should render and match the snapshot 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  gap: 8px;
 }
 
 <div>

--- a/app/components/BaseComponentStyles/margin.ts
+++ b/app/components/BaseComponentStyles/margin.ts
@@ -1,6 +1,15 @@
 import { CSSProperties } from 'react';
 
-export type MarginProps = Pick<CSSProperties, 'margin'> & {
+export type MarginProps = Pick<
+  CSSProperties,
+  | 'margin'
+  | 'marginBlock'
+  | 'marginBlockStart'
+  | 'marginBlockEnd'
+  | 'marginInline'
+  | 'marginInlineStart'
+  | 'marginInlineEnd'
+> & {
   mt?: CSSProperties['marginTop'];
   mb?: CSSProperties['marginBottom'];
   mr?: CSSProperties['marginRight'];
@@ -15,4 +24,10 @@ export const margin = (props: MarginProps) => ({
   marginBottom: props.my ?? props.mb ?? '',
   marginRight: props.mx ?? props.mr ?? '',
   marginLeft: props.mx ?? props.ml ?? '',
+  marginBlock: props.marginBlock ?? '',
+  marginBlockStart: props.marginBlockStart ?? props.marginBlock ?? '',
+  marginBlockEnd: props.marginBlockEnd ?? props.marginBlock ?? '',
+  marginInline: props.marginInline ?? '',
+  marginInlineStart: props.marginInlineStart ?? props.marginInline ?? '',
+  marginInlineEnd: props.marginInlineEnd ?? props.marginInline ?? '',
 });

--- a/app/components/Img/index.js
+++ b/app/components/Img/index.js
@@ -13,6 +13,7 @@ const Img = styled.img.attrs((props) => ({
   ${margin};
   ${style};
   ${positioning};
+  ${({ flipHorizontally }) => flipHorizontally && 'transform: scaleX(-1);'}
 `;
 
 Img.propTypes = {

--- a/app/components/Img/index.js
+++ b/app/components/Img/index.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
 import { memo } from 'react';
 import { layout, margin, style, positioning } from '../BaseComponentStyles';
@@ -13,11 +13,19 @@ const Img = styled.img.attrs((props) => ({
   ${margin};
   ${style};
   ${positioning};
-  ${({ flipHorizontally }) => flipHorizontally && 'transform: scaleX(-1);'}
+  ${({ flipHorizontal }) =>
+    flipHorizontal &&
+    css`
+      -moz-transform: scaleX(-1);
+      -webkit-transform: scaleX(-1);
+      -o-transform: scaleX(-1);
+      transform: scaleX(-1);
+    `}
 `;
 
 Img.propTypes = {
   pointerEvents: PropTypes.string,
+  flipHorizontal: PropTypes.bool,
 };
 
 export default memo(Img);

--- a/app/containers/AnswerSessionPage/components/ActionButtons.tsx
+++ b/app/containers/AnswerSessionPage/components/ActionButtons.tsx
@@ -3,41 +3,32 @@ import { useIntl } from 'react-intl';
 
 import { elements } from 'theme';
 
+import { QuestionTypes } from 'models/Question';
+
 import Row from 'components/Row';
 import { Button } from 'components/Button';
 
 import messages from '../messages';
 import { SkipQuestionButton } from './SkipQuestionButton';
 
-type SkipButtonProps =
-  | {
-      renderSkipQuestionButton: true;
-      onSkipQuestionClick: () => void;
-      skipQuestionButtonDisabled?: boolean;
-      skipButtonStyle?: Record<string, unknown>;
-    }
-  | {
-      renderSkipQuestionButton?: false;
-      onSkipQuestionClick?: undefined;
-      skipQuestionButtonDisabled?: undefined;
-      skipButtonStyle?: undefined;
-    };
+import { NOT_SKIPPABLE_QUESTIONS } from '../constants';
 
-type ContinueButtonProps =
-  | {
-      renderContinueButton: true;
-      onContinueClick: () => void;
-      continueButtonDisabled?: boolean;
-      continueButtonLoading?: boolean;
-      continueButtonStyle?: Record<string, unknown>;
-    }
-  | {
-      renderContinueButton?: false;
-      onContinueClick?: undefined;
-      continueButtonDisabled?: undefined;
-      continueButtonLoading?: undefined;
-      continueButtonStyle?: undefined;
-    };
+type SkipButtonProps = {
+  questionType: QuestionTypes;
+  questionRequired: boolean;
+  isCatMhSession: boolean;
+  onSkipQuestionClick?: () => void;
+  skipQuestionButtonDisabled?: boolean;
+  skipButtonStyle?: Record<string, unknown>;
+};
+
+type ContinueButtonProps = {
+  renderContinueButton: boolean;
+  continueButtonDisabled?: boolean;
+  onContinueClick?: () => void;
+  continueButtonLoading?: boolean;
+  continueButtonStyle?: Record<string, unknown>;
+};
 
 type CommonProps = {
   containerStyle?: Record<string, unknown>;
@@ -48,7 +39,9 @@ export type ActionButtonsProps = SkipButtonProps &
   CommonProps;
 
 const Component = ({
-  renderSkipQuestionButton,
+  questionType,
+  questionRequired,
+  isCatMhSession,
   skipQuestionButtonDisabled,
   onSkipQuestionClick,
   renderContinueButton,
@@ -60,6 +53,11 @@ const Component = ({
   continueButtonStyle,
 }: ActionButtonsProps) => {
   const { formatMessage } = useIntl();
+
+  const renderSkipQuestionButton =
+    !questionRequired &&
+    !isCatMhSession &&
+    !NOT_SKIPPABLE_QUESTIONS.includes(questionType);
 
   const handleSkipButtonClick = () =>
     onSkipQuestionClick && onSkipQuestionClick();

--- a/app/containers/AnswerSessionPage/components/ActionButtons.tsx
+++ b/app/containers/AnswerSessionPage/components/ActionButtons.tsx
@@ -67,11 +67,21 @@ const Component = ({
   const handleContinueButtonClick = () => onContinueClick && onContinueClick();
 
   return (
-    <Row width="100%" my={20} justify="end" align="center" {...containerStyle}>
+    <Row
+      width="100%"
+      my={20}
+      justify="end"
+      align="center"
+      // TODO detect dir
+      dir="rtl"
+      {...containerStyle}
+    >
       {renderSkipQuestionButton && (
         <SkipQuestionButton
           onClick={handleSkipButtonClick}
           disabled={skipQuestionButtonDisabled}
+          // TODO detect dir
+          dir="rtl"
           {...skipButtonStyle}
         />
       )}

--- a/app/containers/AnswerSessionPage/components/ActionButtons.tsx
+++ b/app/containers/AnswerSessionPage/components/ActionButtons.tsx
@@ -73,7 +73,6 @@ const Component = ({
       justify="end"
       align="center"
       // TODO detect dir
-      dir="rtl"
       {...containerStyle}
     >
       {renderSkipQuestionButton && (
@@ -81,7 +80,6 @@ const Component = ({
           onClick={handleSkipButtonClick}
           disabled={skipQuestionButtonDisabled}
           // TODO detect dir
-          dir="rtl"
           {...skipButtonStyle}
         />
       )}

--- a/app/containers/AnswerSessionPage/components/ActionButtons.tsx
+++ b/app/containers/AnswerSessionPage/components/ActionButtons.tsx
@@ -67,19 +67,11 @@ const Component = ({
   const handleContinueButtonClick = () => onContinueClick && onContinueClick();
 
   return (
-    <Row
-      width="100%"
-      my={20}
-      justify="end"
-      align="center"
-      // TODO detect dir
-      {...containerStyle}
-    >
+    <Row width="100%" my={20} justify="end" align="center" {...containerStyle}>
       {renderSkipQuestionButton && (
         <SkipQuestionButton
           onClick={handleSkipButtonClick}
           disabled={skipQuestionButtonDisabled}
-          // TODO detect dir
           {...skipButtonStyle}
         />
       )}

--- a/app/containers/AnswerSessionPage/components/HenryFordInitialScreen.tsx
+++ b/app/containers/AnswerSessionPage/components/HenryFordInitialScreen.tsx
@@ -47,7 +47,6 @@ const HenryFordInitialScreen = ({
       verifyingError={error}
       hfhsPatientDetail={hfhsPatientDetail}
       disabled={patientDetailProvided || disabled}
-      showContinueButton
     />
   );
 };

--- a/app/containers/AnswerSessionPage/components/ScreenBackButton.tsx
+++ b/app/containers/AnswerSessionPage/components/ScreenBackButton.tsx
@@ -31,12 +31,7 @@ const ScreenBackButton: FC<Props> = ({
         visible={disabled}
         text={disabledMessage}
       >
-        <BackButton
-          link={false}
-          disabled={disabled}
-          direction={direction}
-          {...props}
-        >
+        <BackButton disabled={disabled} direction={direction} {...props}>
           {formatMessage(messages.backButton)}
         </BackButton>
       </Tooltip>

--- a/app/containers/AnswerSessionPage/components/ScreenBackButton.tsx
+++ b/app/containers/AnswerSessionPage/components/ScreenBackButton.tsx
@@ -1,5 +1,8 @@
 import React, { FC, memo } from 'react';
 import { useIntl } from 'react-intl';
+import { useSelector } from 'react-redux';
+
+import { makeSelectInterventionFixedElementsDirection } from 'global/reducers/intervention';
 
 import BackButton, { Props as BackButtonProps } from 'components/BackButton';
 import Box from 'components/Box';
@@ -19,6 +22,8 @@ const ScreenBackButton: FC<Props> = ({
 }) => {
   const { formatMessage } = useIntl();
 
+  const direction = useSelector(makeSelectInterventionFixedElementsDirection());
+
   return (
     <Box flexShrink={0}>
       <Tooltip
@@ -26,7 +31,12 @@ const ScreenBackButton: FC<Props> = ({
         visible={disabled}
         text={disabledMessage}
       >
-        <BackButton link={false} disabled={disabled} {...props}>
+        <BackButton
+          link={false}
+          disabled={disabled}
+          direction={direction}
+          {...props}
+        >
           {formatMessage(messages.backButton)}
         </BackButton>
       </Tooltip>

--- a/app/containers/AnswerSessionPage/components/ScreenBackButton.tsx
+++ b/app/containers/AnswerSessionPage/components/ScreenBackButton.tsx
@@ -2,7 +2,7 @@ import React, { FC, memo } from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 
-import { makeSelectInterventionFixedElementsDirection } from 'global/reducers/intervention';
+import { makeSelectInterventionFixedElementsDirection } from 'global/reducers/globalState';
 
 import BackButton, { Props as BackButtonProps } from 'components/BackButton';
 import Box from 'components/Box';

--- a/app/containers/AnswerSessionPage/components/ScreenBackButton.tsx
+++ b/app/containers/AnswerSessionPage/components/ScreenBackButton.tsx
@@ -4,16 +4,17 @@ import { useSelector } from 'react-redux';
 
 import { makeSelectInterventionFixedElementsDirection } from 'global/reducers/globalState';
 
-import BackButton, { Props as BackButtonProps } from 'components/BackButton';
+import BackButton from 'components/BackButton';
 import Box from 'components/Box';
 import { Tooltip } from 'components/Tooltip';
 
 import messages from '../messages';
 
 export type Props = {
-  onClick: () => void;
-  disabledMessage: string;
-} & Pick<BackButtonProps, 'disabled'>;
+  onClick?: () => void;
+  disabled?: boolean;
+  disabledMessage?: string;
+};
 
 const ScreenBackButton: FC<Props> = ({
   disabledMessage,
@@ -28,7 +29,7 @@ const ScreenBackButton: FC<Props> = ({
     <Box flexShrink={0}>
       <Tooltip
         id="back-button-tooltip-id"
-        visible={disabled}
+        visible={disabled && !!disabledMessage}
         text={disabledMessage}
       >
         <BackButton disabled={disabled} direction={direction} {...props}>

--- a/app/containers/AnswerSessionPage/components/SkipQuestionButton.js
+++ b/app/containers/AnswerSessionPage/components/SkipQuestionButton.js
@@ -1,10 +1,14 @@
 import React, { memo } from 'react';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 
 import TriangleForwardIcon from 'assets/svg/triangle-forward.svg';
 
 import { themeColors } from 'theme';
+
+import { makeSelectInterventionFixedElementsDirection } from 'global/reducers/intervention';
+import { LanguageDirection } from 'global/types/locale';
 
 import TextButton from 'components/Button/TextButton';
 import Text from 'components/Text';
@@ -12,8 +16,10 @@ import Img from 'components/Img';
 
 import messages from '../messages';
 
-const Component = ({ onClick, disabled, dir }) => {
+const Component = ({ onClick, disabled }) => {
   const { formatMessage } = useIntl();
+
+  const direction = useSelector(makeSelectInterventionFixedElementsDirection());
 
   return (
     <TextButton
@@ -23,7 +29,6 @@ const Component = ({ onClick, disabled, dir }) => {
         display: 'flex',
         align: 'center',
         gap: 8,
-        dir,
       }}
     >
       <Text color={themeColors.secondary} fontWeight="bold">
@@ -32,7 +37,7 @@ const Component = ({ onClick, disabled, dir }) => {
       <Img
         src={TriangleForwardIcon}
         alt={formatMessage(messages.skipIconAlt)}
-        flipHorizontally={!dir || dir === 'ltr'}
+        flipHorizontal={direction === LanguageDirection.RTL}
       />
     </TextButton>
   );
@@ -41,7 +46,6 @@ const Component = ({ onClick, disabled, dir }) => {
 Component.propTypes = {
   onClick: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
-  dir: PropTypes.oneOf(['ltr', 'rtl']),
 };
 
 export const SkipQuestionButton = memo(Component);

--- a/app/containers/AnswerSessionPage/components/SkipQuestionButton.js
+++ b/app/containers/AnswerSessionPage/components/SkipQuestionButton.js
@@ -29,6 +29,7 @@ const Component = ({ onClick, disabled }) => {
         display: 'flex',
         align: 'center',
         gap: 8,
+        dir: direction,
       }}
     >
       <Text color={themeColors.secondary} fontWeight="bold">

--- a/app/containers/AnswerSessionPage/components/SkipQuestionButton.js
+++ b/app/containers/AnswerSessionPage/components/SkipQuestionButton.js
@@ -2,7 +2,7 @@ import React, { memo } from 'react';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 
-import triangleBack from 'assets/svg/triangle-back.svg';
+import TriangleForwardIcon from 'assets/svg/triangle-forward.svg';
 
 import { themeColors } from 'theme';
 
@@ -30,7 +30,7 @@ const Component = ({ onClick, disabled, dir }) => {
         {formatMessage(messages.skipQuestion)}
       </Text>
       <Img
-        src={triangleBack}
+        src={TriangleForwardIcon}
         alt={formatMessage(messages.skipIconAlt)}
         flipHorizontally={!dir || dir === 'ltr'}
       />

--- a/app/containers/AnswerSessionPage/components/SkipQuestionButton.js
+++ b/app/containers/AnswerSessionPage/components/SkipQuestionButton.js
@@ -12,7 +12,7 @@ import Img from 'components/Img';
 
 import messages from '../messages';
 
-const Component = ({ onClick, disabled }) => {
+const Component = ({ onClick, disabled, dir }) => {
   const { formatMessage } = useIntl();
 
   return (
@@ -23,6 +23,7 @@ const Component = ({ onClick, disabled }) => {
         display: 'flex',
         align: 'center',
         gap: 8,
+        dir,
       }}
     >
       <Text color={themeColors.secondary} fontWeight="bold">
@@ -31,7 +32,7 @@ const Component = ({ onClick, disabled }) => {
       <Img
         src={triangleBack}
         alt={formatMessage(messages.skipIconAlt)}
-        transform="scaleX(-1)"
+        flipHorizontally={!dir || dir === 'ltr'}
       />
     </TextButton>
   );
@@ -40,6 +41,7 @@ const Component = ({ onClick, disabled }) => {
 Component.propTypes = {
   onClick: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
+  dir: PropTypes.oneOf(['ltr', 'rtl']),
 };
 
 export const SkipQuestionButton = memo(Component);

--- a/app/containers/AnswerSessionPage/components/SkipQuestionButton.js
+++ b/app/containers/AnswerSessionPage/components/SkipQuestionButton.js
@@ -7,7 +7,7 @@ import TriangleForwardIcon from 'assets/svg/triangle-forward.svg';
 
 import { themeColors } from 'theme';
 
-import { makeSelectInterventionFixedElementsDirection } from 'global/reducers/intervention';
+import { makeSelectInterventionFixedElementsDirection } from 'global/reducers/globalState';
 import { LanguageDirection } from 'global/types/locale';
 
 import TextButton from 'components/Button/TextButton';

--- a/app/containers/AnswerSessionPage/components/styled.js
+++ b/app/containers/AnswerSessionPage/components/styled.js
@@ -5,7 +5,7 @@ import { animationDuration } from 'utils/animationsHelpers/constants';
 export const NarratorContainer = styled.div`
   position: absolute;
   top: 0;
-  left: 0;
+  inset-inline-start: 0;
   height: 0;
   width: 0;
 

--- a/app/containers/AnswerSessionPage/components/tests/__snapshots__/CharacterAnim.test.js.snap
+++ b/app/containers/AnswerSessionPage/components/tests/__snapshots__/CharacterAnim.test.js.snap
@@ -4,7 +4,7 @@ exports[`<CharacterAnim /> Should render and match the snapshot 1`] = `
 .c0 {
   position: absolute;
   top: 0;
-  left: 0;
+  inset-inline-start: 0;
   height: 0;
   width: 0;
 }

--- a/app/containers/AnswerSessionPage/components/tests/__snapshots__/FinishScreen.test.js.snap
+++ b/app/containers/AnswerSessionPage/components/tests/__snapshots__/FinishScreen.test.js.snap
@@ -46,6 +46,7 @@ exports[`<FinishScreen /> Should render and match the snapshot 1`] = `
 <div>
   <div
     class="c0"
+    dir="ltr"
     width="100%"
   >
     <a

--- a/app/containers/AnswerSessionPage/index.js
+++ b/app/containers/AnswerSessionPage/index.js
@@ -33,6 +33,7 @@ import {
   fetchInterventionSaga,
   makeSelectInterventionStatus,
   interventionReducer,
+  makeSelectInterventionFixedElementsDirection,
 } from 'global/reducers/intervention';
 import {
   editPhoneNumberQuestionSaga,
@@ -219,6 +220,7 @@ export function AnswerSessionPage({
   saveQuickExitEvent,
   resetAnswerSessionPage,
   fetchPreviousQuestion,
+  fixedElementsDirection,
 }) {
   const { formatMessage } = useIntl();
   const history = useHistory();
@@ -562,6 +564,7 @@ export function AnswerSessionPage({
               mt={isMobile ? 32 : 16}
               align={isMobile ? 'end' : 'center'}
               gap={16}
+              dir={fixedElementsDirection}
             >
               <ScreenBackButton
                 onClick={onBackButtonClick}
@@ -602,7 +605,7 @@ export function AnswerSessionPage({
           )}
 
           {!isNarratorPositionFixed && (
-            <Row align="center" gap={16}>
+            <Row align="center" gap={16} dir={fixedElementsDirection}>
               <ScreenBackButton
                 onClick={onBackButtonClick}
                 disabled={backButtonDisabled}
@@ -970,12 +973,14 @@ AnswerSessionPage.propTypes = {
   resetAnswerSessionPage: PropTypes.func,
   resetAllReducers: PropTypes.func,
   fetchPreviousQuestion: PropTypes.func,
+  fixedElementsDirection: PropTypes.bool,
 };
 
 const mapStateToProps = createStructuredSelector({
   AnswerSessionPage: makeSelectAnswerSessionPage(),
   audioInstance: makeSelectAudioInstance(),
   interventionStatus: makeSelectInterventionStatus(),
+  fixedElementsDirection: makeSelectInterventionFixedElementsDirection(),
 });
 
 const mapDispatchToProps = {

--- a/app/containers/AnswerSessionPage/index.js
+++ b/app/containers/AnswerSessionPage/index.js
@@ -27,13 +27,15 @@ import { DESKTOP_MODE, I_PHONE_8_PLUS_MODE } from 'utils/previewMode';
 import { CHARACTER_FIXED_POSITION_QUESTIONS } from 'utils/characterConstants';
 import LocalStorageService from 'utils/localStorageService';
 
-import { makeSelectAudioInstance } from 'global/reducers/globalState';
+import {
+  makeSelectAudioInstance,
+  makeSelectInterventionFixedElementsDirection,
+} from 'global/reducers/globalState';
 import {
   fetchInterventionRequest,
   fetchInterventionSaga,
   makeSelectInterventionStatus,
   interventionReducer,
-  makeSelectInterventionFixedElementsDirection,
 } from 'global/reducers/intervention';
 import {
   editPhoneNumberQuestionSaga,

--- a/app/containers/AnswerSessionPage/index.js
+++ b/app/containers/AnswerSessionPage/index.js
@@ -110,7 +110,6 @@ import {
 } from './actions';
 import BranchingScreen from './components/BranchingScreen';
 import {
-  NOT_SKIPPABLE_QUESTIONS,
   FULL_SIZE_QUESTIONS,
   CONFIRMABLE_QUESTIONS,
   NO_CONTINUE_BUTTON_QUESTIONS,
@@ -510,12 +509,6 @@ export function AnswerSessionPage({
 
     const canSkipNarrator = narratorSkippable || !isAnimationOngoing;
 
-    const shouldRenderSkipQuestionButton =
-      !required &&
-      !isCatMhSession &&
-      !isLastScreen &&
-      !NOT_SKIPPABLE_QUESTIONS.includes(type);
-
     const shouldRenderContinueButton =
       (isNullOrUndefined(proceedButton) || proceedButton) &&
       canSkipNarrator &&
@@ -583,7 +576,9 @@ export function AnswerSessionPage({
                 audioInstance={audioInstance}
               >
                 <ActionButtons
-                  renderSkipQuestionButton={shouldRenderSkipQuestionButton}
+                  questionType={type}
+                  questionRequired={required}
+                  isCatMhSession={isCatMhSession}
                   skipQuestionButtonDisabled={continueButtonLoading}
                   onSkipQuestionClick={() => setSkipQuestionModalVisible(true)}
                   renderContinueButton={shouldRenderContinueButton}
@@ -614,7 +609,9 @@ export function AnswerSessionPage({
                 disabledMessage={backButtonDisabledMessage()}
               />
               <ActionButtons
-                renderSkipQuestionButton={shouldRenderSkipQuestionButton}
+                questionType={type}
+                questionRequired={required}
+                isCatMhSession={isCatMhSession}
                 skipQuestionButtonDisabled={continueButtonLoading}
                 onSkipQuestionClick={() => setSkipQuestionModalVisible(true)}
                 renderContinueButton={shouldRenderContinueButton}

--- a/app/containers/AnswerSessionPage/layouts/FinishScreenLayout.tsx
+++ b/app/containers/AnswerSessionPage/layouts/FinishScreenLayout.tsx
@@ -11,7 +11,7 @@ import { FinishQuestionDTO } from 'models/Question';
 import { useRoleManager } from 'models/User/RolesManager';
 
 import { resetReducer as resetAuthReducer } from 'global/reducers/auth/actions';
-import { makeSelectInterventionFixedElementsDirection } from 'global/reducers/intervention';
+import { makeSelectInterventionFixedElementsDirection } from 'global/reducers/globalState';
 import { RoutePath } from 'global/constants';
 
 import Button, { TextButton } from 'components/Button';

--- a/app/containers/AnswerSessionPage/layouts/FinishScreenLayout.tsx
+++ b/app/containers/AnswerSessionPage/layouts/FinishScreenLayout.tsx
@@ -11,6 +11,7 @@ import { FinishQuestionDTO } from 'models/Question';
 import { useRoleManager } from 'models/User/RolesManager';
 
 import { resetReducer as resetAuthReducer } from 'global/reducers/auth/actions';
+import { makeSelectInterventionFixedElementsDirection } from 'global/reducers/intervention';
 import { RoutePath } from 'global/constants';
 
 import Button, { TextButton } from 'components/Button';
@@ -37,6 +38,10 @@ const FinishScreenLayout = ({ formatMessage, question }: Props) => {
 
   const dispatch = useDispatch();
   const userSession = useSelector(makeSelectUserSession());
+
+  const fixedElementsDirection = useSelector(
+    makeSelectInterventionFixedElementsDirection(),
+  );
 
   const {
     id: userSessionId,
@@ -88,7 +93,7 @@ const FinishScreenLayout = ({ formatMessage, question }: Props) => {
 
   if (isGuestUser) {
     return (
-      <Row mt={50} justify="center" width="100%">
+      <Row mt={50} justify="center" width="100%" dir={fixedElementsDirection}>
         <Button onClick={reloadPage} px={20} width="auto">
           {formatMessage(messages.completeSession)}
         </Button>
@@ -99,7 +104,14 @@ const FinishScreenLayout = ({ formatMessage, question }: Props) => {
 
   if (showModulesButtons)
     return (
-      <Row mt={50} align="center" justify="end" width="100%" gap={15}>
+      <Row
+        mt={50}
+        align="center"
+        justify="end"
+        width="100%"
+        gap={15}
+        dir={fixedElementsDirection}
+      >
         <StyledLink
           to={parametrizeRoutePath(RoutePath.USER_INTERVENTION, {
             userInterventionId,
@@ -130,7 +142,13 @@ const FinishScreenLayout = ({ formatMessage, question }: Props) => {
   };
 
   return (
-    <Row mt={50} justify="center" width="100%" gap={15}>
+    <Row
+      mt={50}
+      justify="center"
+      width="100%"
+      gap={15}
+      dir={fixedElementsDirection}
+    >
       {isPreview && (
         <StyledLink to={sessionMapUrl}>
           <Button onClick={closeOpenerTab} px={20} inverted>

--- a/app/containers/AnswerSessionPage/layouts/HenryFordInitialScreenLayout.tsx
+++ b/app/containers/AnswerSessionPage/layouts/HenryFordInitialScreenLayout.tsx
@@ -124,23 +124,23 @@ const emptyInitialValues: PatientDataFormValues = {
 export type Props = {
   forceMobile?: boolean;
   disabled?: boolean;
-  showContinueButton?: boolean;
   onSubmitPatientData?: (patientData: HfhsPatientData) => void;
   verifying?: boolean;
   verifyingError?: Nullable<ApiMessageError>;
   hfhsPatientDetail?: Nullable<HfhsPatientDetail>;
   previewMedicalNumberInput?: boolean;
+  continueButtonDisabled?: boolean;
 };
 
 const HenryFordInitialScreenLayout = ({
   forceMobile,
   disabled,
-  showContinueButton,
   onSubmitPatientData,
   verifying = false,
   verifyingError,
   hfhsPatientDetail,
   previewMedicalNumberInput,
+  continueButtonDisabled,
 }: Props) => {
   const { formatMessage } = useIntl();
 
@@ -376,19 +376,17 @@ const HenryFordInitialScreenLayout = ({
               formError === PatientDataFormError.MRN_VERIFICATION && (
                 <ApiErrorMessage error={verifyingError} />
               )}
-            {showContinueButton && (
-              <Box dir={fixedElementsDirection}>
-                <ActionButtons
-                  questionRequired
-                  questionType={QuestionTypes.HENRY_FORD_INITIAL}
-                  isCatMhSession={false}
-                  renderContinueButton
-                  continueButtonDisabled={!isValid}
-                  continueButtonLoading={verifying}
-                  onContinueClick={handleSubmit}
-                />
-              </Box>
-            )}
+            <Box dir={fixedElementsDirection}>
+              <ActionButtons
+                questionRequired
+                questionType={QuestionTypes.HENRY_FORD_INITIAL}
+                isCatMhSession={false}
+                renderContinueButton
+                continueButtonDisabled={!isValid || continueButtonDisabled}
+                continueButtonLoading={verifying}
+                onContinueClick={handleSubmit}
+              />
+            </Box>
           </Box>
         </Form>
       )}

--- a/app/containers/AnswerSessionPage/layouts/HenryFordInitialScreenLayout.tsx
+++ b/app/containers/AnswerSessionPage/layouts/HenryFordInitialScreenLayout.tsx
@@ -29,8 +29,8 @@ import {
 import { ApiMessageError } from 'models/Api';
 
 import {
-  requiredValidationSchema,
   nameValidationSchema,
+  requiredValidationSchema,
 } from 'utils/validators';
 import { getUTCDateString } from 'utils/dateUtils';
 
@@ -44,15 +44,16 @@ import FormikDatePicker from 'components/FormikDatePicker';
 import Text from 'components/Text';
 import { HelpIconTooltip } from 'components/HelpIconTooltip';
 import {
+  DEFAULT_COUNTRY_CODE,
   FormikPhoneNumberInput,
   phoneNumberSchema,
-  DEFAULT_COUNTRY_CODE,
 } from 'components/FormikPhoneNumberInput';
 
 import { formatPhoneNumberForHfhs, parsePhoneNumberFromHfhs } from '../utils';
 import { ActionButtons } from '../components/ActionButtons';
 import { ApiErrorMessage } from '../components/ApiErrorMessage';
 import messages from './messages';
+import { QuestionTypes } from '../../../models/Question';
 
 const inputStyles = {
   width: '100%',
@@ -378,6 +379,9 @@ const HenryFordInitialScreenLayout = ({
             {showContinueButton && (
               <Box dir={fixedElementsDirection}>
                 <ActionButtons
+                  questionRequired
+                  questionType={QuestionTypes.HENRY_FORD_INITIAL}
+                  isCatMhSession={false}
                   renderContinueButton
                   continueButtonDisabled={!isValid}
                   continueButtonLoading={verifying}

--- a/app/containers/AnswerSessionPage/layouts/HenryFordInitialScreenLayout.tsx
+++ b/app/containers/AnswerSessionPage/layouts/HenryFordInitialScreenLayout.tsx
@@ -34,7 +34,7 @@ import {
 } from 'utils/validators';
 import { getUTCDateString } from 'utils/dateUtils';
 
-import { makeSelectInterventionFixedElementsDirection } from 'global/reducers/intervention';
+import { makeSelectInterventionFixedElementsDirection } from 'global/reducers/globalState';
 
 import Box from 'components/Box';
 import { SelectOption } from 'components/Select/types';

--- a/app/containers/AnswerSessionPage/layouts/HenryFordInitialScreenLayout.tsx
+++ b/app/containers/AnswerSessionPage/layouts/HenryFordInitialScreenLayout.tsx
@@ -11,6 +11,7 @@ import { Form, Formik, FormikConfig, FormikProps } from 'formik';
 import * as Yup from 'yup';
 import { IntlShape } from 'react-intl/src/types';
 import { CountryCode } from 'libphonenumber-js/types';
+import { useSelector } from 'react-redux';
 
 import { colors, themeColors } from 'theme';
 
@@ -32,6 +33,8 @@ import {
   nameValidationSchema,
 } from 'utils/validators';
 import { getUTCDateString } from 'utils/dateUtils';
+
+import { makeSelectInterventionFixedElementsDirection } from 'global/reducers/intervention';
 
 import Box from 'components/Box';
 import { SelectOption } from 'components/Select/types';
@@ -139,6 +142,10 @@ const HenryFordInitialScreenLayout = ({
   previewMedicalNumberInput,
 }: Props) => {
   const { formatMessage } = useIntl();
+
+  const fixedElementsDirection = useSelector(
+    makeSelectInterventionFixedElementsDirection(),
+  );
 
   const columnClassMap: ScreenClassMap<number> = {
     xs: 12,
@@ -369,7 +376,7 @@ const HenryFordInitialScreenLayout = ({
                 <ApiErrorMessage error={verifyingError} />
               )}
             {showContinueButton && (
-              <Box>
+              <Box dir={fixedElementsDirection}>
                 <ActionButtons
                   renderContinueButton
                   continueButtonDisabled={!isValid}

--- a/app/containers/AnswerSessionPage/selectors.js
+++ b/app/containers/AnswerSessionPage/selectors.js
@@ -85,6 +85,12 @@ const makeSelectHfhsPatientDetail = () =>
     ({ hfhsPatientDetail }) => hfhsPatientDetail,
   );
 
+const makeSelectUserSessionLanguageCode = () =>
+  createSelector(
+    selectAnswerSessionPageDomain,
+    (substate) => substate.userSession?.languageCode,
+  );
+
 export default makeSelectAnswerSessionPage;
 export {
   selectAnswerSessionPageDomain,
@@ -99,4 +105,5 @@ export {
   makeSelectShowTextReadingControls,
   makeSelectVerifyPatientDataState,
   makeSelectHfhsPatientDetail,
+  makeSelectUserSessionLanguageCode,
 };

--- a/app/containers/AppLanguageProvider/reducer.js
+++ b/app/containers/AppLanguageProvider/reducer.js
@@ -1,6 +1,6 @@
 import produce from 'immer';
 
-import { DEFAULT_LOCALE } from 'i18n';
+import { DEFAULT_LOCALE, isAppLanguageSupported } from 'i18n';
 
 import { CHANGE_LOCALE } from './constants';
 
@@ -13,7 +13,8 @@ const appLanguageProviderReducer = (state = initialState, action) =>
   produce(state, (draft) => {
     switch (action.type) {
       case CHANGE_LOCALE:
-        draft.locale = action.locale;
+        const { locale } = action;
+        draft.locale = isAppLanguageSupported(locale) ? locale : DEFAULT_LOCALE;
         break;
     }
   });

--- a/app/containers/AppLanguageProvider/tests/reducer.test.js
+++ b/app/containers/AppLanguageProvider/tests/reducer.test.js
@@ -13,10 +13,10 @@ describe('appLanguageProviderReducer', () => {
     expect(
       appLanguageProviderReducer(undefined, {
         type: CHANGE_LOCALE,
-        locale: 'de',
+        locale: 'ar',
       }),
     ).toEqual({
-      locale: 'de',
+      locale: 'ar',
     });
   });
 });

--- a/app/containers/InterventionDetailsPage/containers/ParticipantInviter/CreatePredefinedParticipantView.tsx
+++ b/app/containers/InterventionDetailsPage/containers/ParticipantInviter/CreatePredefinedParticipantView.tsx
@@ -14,7 +14,7 @@ import Column from 'components/Column';
 import { SelectOption } from 'components/Select/types';
 import { Alert } from 'components/Alert';
 
-import { BackButton } from './BackButton';
+import { InviteParticipantsModalBackButton } from './InviteParticipantsModalBackButton';
 import {
   InviteParticipantModalView,
   InviteParticipantModalViewState,
@@ -67,7 +67,7 @@ export const CreatePredefinedParticipantView: FC<Props> = ({
 
   return (
     <Column flex={1} overflow="auto" gap={24}>
-      <BackButton
+      <InviteParticipantsModalBackButton
         invitationType={ParticipantInvitationType.PREDEFINED}
         onBack={onBack}
       />

--- a/app/containers/InterventionDetailsPage/containers/ParticipantInviter/InviteEmailParticipantsView.tsx
+++ b/app/containers/InterventionDetailsPage/containers/ParticipantInviter/InviteEmailParticipantsView.tsx
@@ -10,7 +10,7 @@ import {
 import Column from 'components/Column';
 import { SelectOption } from 'components/Select/types';
 
-import { BackButton } from './BackButton';
+import { InviteParticipantsModalBackButton } from './InviteParticipantsModalBackButton';
 import {
   NormalizedHealthClinicsInfos,
   ParticipantInvitationType,
@@ -61,7 +61,7 @@ export const InviteEmailParticipantsView: FC<Props> = ({
 
   return (
     <Column flex={1} overflow="auto" gap={24}>
-      <BackButton
+      <InviteParticipantsModalBackButton
         invitationType={ParticipantInvitationType.EMAIL}
         onBack={onBack}
       />

--- a/app/containers/InterventionDetailsPage/containers/ParticipantInviter/InviteParticipantsModalBackButton.tsx
+++ b/app/containers/InterventionDetailsPage/containers/ParticipantInviter/InviteParticipantsModalBackButton.tsx
@@ -1,10 +1,7 @@
 import React, { FC } from 'react';
 import { useIntl } from 'react-intl';
 
-import TriangleBackIcon from 'assets/svg/triangle-back.svg';
-
-import { TextButton } from 'components/Button';
-import Icon from 'components/Icon';
+import BackButton from 'components/BackButton';
 import Row from 'components/Row';
 
 import { ParticipantInvitationType } from './types';
@@ -24,10 +21,9 @@ export const InviteParticipantsModalBackButton: FC<Props> = ({
 
   return (
     <Row>
-      <TextButton onClick={() => onBack()} buttonProps={TEXT_BUTTON_PROPS}>
-        <Icon src={TriangleBackIcon} />
+      <BackButton onClick={() => onBack()} {...TEXT_BUTTON_PROPS}>
         {formatMessage(messages.backButtonTitle, { invitationType })}
-      </TextButton>
+      </BackButton>
     </Row>
   );
 };

--- a/app/containers/InterventionDetailsPage/containers/ParticipantInviter/InviteParticipantsModalBackButton.tsx
+++ b/app/containers/InterventionDetailsPage/containers/ParticipantInviter/InviteParticipantsModalBackButton.tsx
@@ -16,7 +16,10 @@ export type Props = {
   onBack: () => void;
 };
 
-export const BackButton: FC<Props> = ({ invitationType, onBack }) => {
+export const InviteParticipantsModalBackButton: FC<Props> = ({
+  invitationType,
+  onBack,
+}) => {
   const { formatMessage } = useIntl();
 
   return (

--- a/app/containers/InterventionDetailsPage/containers/ParticipantInviter/ManagePredefinedParticipantView.tsx
+++ b/app/containers/InterventionDetailsPage/containers/ParticipantInviter/ManagePredefinedParticipantView.tsx
@@ -23,7 +23,7 @@ import { SelectOption } from 'components/Select/types';
 import Row from 'components/Row';
 import { Button } from 'components/Button';
 
-import { BackButton } from './BackButton';
+import { InviteParticipantsModalBackButton } from './InviteParticipantsModalBackButton';
 import {
   ParticipantInvitationType,
   PredefinedParticipantFormMode,
@@ -117,7 +117,7 @@ export const ManagePredefinedParticipantView: FC<Props> = ({
 
   return (
     <Column flex={1} overflow="auto" gap={24}>
-      <BackButton
+      <InviteParticipantsModalBackButton
         invitationType={ParticipantInvitationType.PREDEFINED}
         onBack={onBack}
       />

--- a/app/containers/InterventionDetailsPage/containers/ParticipantInviter/UploadEmailsView.tsx
+++ b/app/containers/InterventionDetailsPage/containers/ParticipantInviter/UploadEmailsView.tsx
@@ -17,7 +17,7 @@ import CsvFileExport from 'components/CsvFileExport';
 import CsvFileReader from 'components/CsvFileReader';
 import Row from 'components/Row';
 
-import { BackButton } from './BackButton';
+import { InviteParticipantsModalBackButton } from './InviteParticipantsModalBackButton';
 import {
   EmailsCsvRow,
   InviteEmailParticipantsFormValues,
@@ -115,7 +115,7 @@ export const UploadEmailsView: FC<Props> = ({
 
   return (
     <Column flex={1} overflow="auto" gap={24}>
-      <BackButton
+      <InviteParticipantsModalBackButton
         invitationType={ParticipantInvitationType.EMAIL}
         onBack={onBack}
       />

--- a/app/containers/QuestionTranscript/QuestionTranscriptUI.js
+++ b/app/containers/QuestionTranscript/QuestionTranscriptUI.js
@@ -1,7 +1,6 @@
-import React, { memo, useMemo } from 'react';
+import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { getLangDir } from 'rtl-detect';
 
 import Box from 'components/Box';
 import { ScrollFogBox } from 'components/Box/ScrollFog';
@@ -16,19 +15,17 @@ import TextBlock from './TextBlock';
 const QuestionTranscriptUI = ({ texts, currentBlockIndex, language }) => {
   const { formatMessage } = useIntl();
 
-  const langDir = useMemo(() => getLangDir(language), [language]);
-
   return (
     <Column height="100%">
       <H3 mb={16}>{formatMessage(messages.header)}</H3>
-      <TranscriptBox lang={language} dir={langDir}>
+      <TranscriptBox lang={language} dir="auto">
         <ScrollFogBox overflow="scroll" borderRadius="0px">
           {texts.map(({ text, realIndex }, index) => (
             <Box key={`Block-Transcript-${index}`}>
               <TextBlock
                 text={text}
                 isCurrent={realIndex === currentBlockIndex}
-                dir={langDir}
+                dir="auto"
               />
               <br />
             </Box>

--- a/app/containers/Sessions/components/QuestionData/HenryFordInitialScreen/index.tsx
+++ b/app/containers/Sessions/components/QuestionData/HenryFordInitialScreen/index.tsx
@@ -7,7 +7,11 @@ import { CommonQuestionProps } from '../types';
 type Props = CommonQuestionProps;
 
 const HenryFordInitialScreen: React.FC<Props> = () => (
-  <HenryFordInitialScreenLayout disabled previewMedicalNumberInput />
+  <HenryFordInitialScreenLayout
+    disabled
+    continueButtonDisabled
+    previewMedicalNumberInput
+  />
 );
 
 export default HenryFordInitialScreen;

--- a/app/containers/Sessions/components/QuestionDetails/index.tsx
+++ b/app/containers/Sessions/components/QuestionDetails/index.tsx
@@ -135,10 +135,15 @@ const RenderQuestionDetails = ({
 
   const isNameScreen = type === QuestionTypes.NAME;
   const isFinishScreen = type === QuestionTypes.FINISH;
+  const isHenryFordInitialScreen = type === QuestionTypes.HENRY_FORD_INITIAL;
   const isTlfbGroup = currentGroupScope?.type === GroupType.TLFB;
   const shouldShowNarrator =
     !!blocks?.length && !HIDE_NARRATOR_QUESTIONS.includes(type);
-  const renderContinueButton = proceedButton && !isTlfbGroup && !isFinishScreen;
+  const renderContinueButton =
+    proceedButton &&
+    !isTlfbGroup &&
+    !isFinishScreen &&
+    !isHenryFordInitialScreen;
 
   const { character, extra_space_for_narrator: extraSpaceForNarrator } =
     narratorSettings;

--- a/app/containers/Sessions/components/QuestionDetails/index.tsx
+++ b/app/containers/Sessions/components/QuestionDetails/index.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useRef } from 'react';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 import { useInjectSaga } from 'redux-injectors';
 import { defaults } from 'lodash';
@@ -21,8 +21,11 @@ import {
   makeSelectIntervention,
 } from 'global/reducers/intervention';
 import questionTypesMessages from 'global/i18n/questionTypesMessages';
+import { makeSelectInterventionFixedElementsDirection } from 'global/reducers/globalState';
 
 import CommonLayout from 'containers/AnswerSessionPage/layouts/CommonLayout';
+import ScreenBackButton from 'containers/AnswerSessionPage/components/ScreenBackButton';
+import { ActionButtons } from 'containers/AnswerSessionPage/components/ActionButtons';
 
 import Box from 'components/Box';
 import Column from 'components/Column';
@@ -30,7 +33,6 @@ import AppContainer from 'components/Container';
 import Row from 'components/Row';
 import StyledInput from 'components/Input/StyledInput';
 import { selectInputText } from 'components/Input/utils';
-import { Button } from 'components/Button';
 import Img from 'components/Img';
 import Text from 'components/Text';
 import { HelpIconTooltip } from 'components/HelpIconTooltip';
@@ -81,6 +83,10 @@ const RenderQuestionDetails = ({
 
   const isNarratorTab: boolean = useSelector(makeSelectIsNarratorTab());
 
+  const fixedElementsDirection = useSelector(
+    makeSelectInterventionFixedElementsDirection(),
+  );
+
   useInjectSaga({ key: 'editQuestion', saga: editQuestionSaga });
   const animationBoundaries = useRef(null);
 
@@ -108,13 +114,22 @@ const RenderQuestionDetails = ({
     narrator: { settings: narratorSettings, blocks },
   } = selectedQuestion;
 
-  const { video, image, title, subtitle } = defaults(
+  const {
+    video,
+    image,
+    title,
+    subtitle,
+    required,
+    proceed_button: proceedButton,
+  } = defaults(
     { ...questionSettings },
     {
       video: false,
       image: false,
       title: false,
       subtitle: false,
+      required: true,
+      proceed_button: true,
     },
   );
 
@@ -123,12 +138,7 @@ const RenderQuestionDetails = ({
   const isTlfbGroup = currentGroupScope?.type === GroupType.TLFB;
   const shouldShowNarrator =
     !!blocks?.length && !HIDE_NARRATOR_QUESTIONS.includes(type);
-
-  const proceedButton =
-    'proceed_button' in questionSettings
-      ? questionSettings.proceed_button
-      : true;
-  const showProceedButton = proceedButton && !isTlfbGroup && !isFinishScreen;
+  const renderContinueButton = proceedButton && !isTlfbGroup && !isFinishScreen;
 
   const { character, extra_space_for_narrator: extraSpaceForNarrator } =
     narratorSettings;
@@ -245,14 +255,17 @@ const RenderQuestionDetails = ({
                   <QuestionData />
                 </Row>
 
-                {showProceedButton && (
-                  <Box my={20} ml={26}>
-                    {/* @ts-ignore */}
-                    <Button width={elements.continueButtonWidth} disabled>
-                      <FormattedMessage {...messages.nextQuestion} />
-                    </Button>
-                  </Box>
-                )}
+                <Row align="center" gap={16} dir={fixedElementsDirection}>
+                  <ScreenBackButton disabled />
+                  <ActionButtons
+                    questionType={type}
+                    questionRequired={required}
+                    isCatMhSession={false}
+                    skipQuestionButtonDisabled
+                    renderContinueButton={renderContinueButton}
+                    continueButtonDisabled
+                  />
+                </Row>
               </AppContainer>
             </Row>
           </AnswerInterventionContent>

--- a/app/containers/Sessions/components/QuestionDetails/messages.ts
+++ b/app/containers/Sessions/components/QuestionDetails/messages.ts
@@ -8,10 +8,6 @@ import { defineMessages } from 'react-intl';
 export const scope = 'app.components.QuestionDetails';
 
 export default defineMessages({
-  nextQuestion: {
-    id: `${scope}.nextQuestion`,
-    defaultMessage: 'Continue',
-  },
   groupPlaceholder: {
     id: `${scope}.groupPlaceholder`,
     defaultMessage: 'Group placeholder',

--- a/app/containers/Sessions/components/QuestionDetails/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/Sessions/components/QuestionDetails/tests/__snapshots__/index.test.js.snap
@@ -115,6 +115,51 @@ exports[`<QuestionDetails /> should match the snapshot 1`] = `
   display: flex;
 }
 
+.c28 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  height: auto;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 16px;
+}
+
+.c34 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  height: auto;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  justify-items: flex-end;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-top: 20px;
+  margin-bottom: 20px;
+  width: 100%;
+}
+
 .c0 {
   width: auto;
   height: auto;
@@ -212,15 +257,33 @@ exports[`<QuestionDetails /> should match the snapshot 1`] = `
   color: unset;
 }
 
-.c28 {
+.c29 {
   width: auto;
   height: auto;
   display: block;
   border-radius: 5px;
-  margin-top: 20px;
-  margin-bottom: 20px;
-  margin-left: 26px;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   color: unset;
+}
+
+.c30 {
+  width: auto;
+  height: auto;
+  display: block;
+  border-radius: 5px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  color: unset;
+}
+
+.c32 {
+  width: auto;
+  height: auto;
+  margin-block-end: 2px;
 }
 
 .c27 {
@@ -231,6 +294,15 @@ exports[`<QuestionDetails /> should match the snapshot 1`] = `
   font-size: 13px;
   color: rgba(107,112,124,1);
   color: rgba(107,112,124,1);
+}
+
+.c33 {
+  font-family: DM Sans;
+  font-size: 13px;
+  line-height: 130%;
+  font-weight: 700;
+  color: rgba(183,39,234,1);
+  color: rgba(183,39,234,1);
 }
 
 .c2 {
@@ -267,7 +339,7 @@ exports[`<QuestionDetails /> should match the snapshot 1`] = `
   width: 100%;
 }
 
-.c29 {
+.c35 {
   width: 100%;
   height: 40px;
   border-radius: 100px;
@@ -281,7 +353,35 @@ exports[`<QuestionDetails /> should match the snapshot 1`] = `
   background-color: #9AA1B6;
   -webkit-transition: background-color 300ms ease,color 300ms ease,border 300ms ease;
   transition: background-color 300ms ease,color 300ms ease,border 300ms ease;
+  margin: 20px;
   width: 120px;
+}
+
+.c31 {
+  outline: none;
+  border: none;
+  background: transparent;
+  font-weight: bold;
+  font-size: 13px;
+  line-height: 17px;
+  padding: 2px;
+  cursor: not-allowed;
+  opacity: 0.7;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-weight: 700;
+  color: #2F3850;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 8px;
+  opacity: 0.5;
 }
 
 .c9 {
@@ -3564,16 +3664,60 @@ exports[`<QuestionDetails /> should match the snapshot 1`] = `
               </div>
               <div
                 class="c28"
+                dir="ltr"
               >
-                <button
+                <div
                   class="c29"
-                  color="primary"
-                  disabled=""
-                  radius="100px"
-                  width="120"
                 >
-                  Continue
-                </button>
+                  <div
+                    class="c30"
+                    display="flex"
+                  >
+                    <div
+                      class="c14"
+                      data-for="back-button-tooltip-id"
+                      data-tip=""
+                    >
+                      <div>
+                        <button
+                          class="c31"
+                          dir="ltr"
+                          disabled=""
+                          display="flex"
+                          font-weight="bold"
+                        >
+                          <img
+                            alt="traingle"
+                            class="c32"
+                            src="IMAGE_MOCK"
+                          />
+                          <p
+                            class="c33"
+                            color="#B727EA"
+                            font-weight="bold"
+                          >
+                            Back
+                          </p>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="c34"
+                  width="100%"
+                >
+                  <button
+                    class="c35"
+                    color="primary"
+                    data-cy="continue-button"
+                    disabled=""
+                    radius="100px"
+                    width="120"
+                  >
+                    Continue
+                  </button>
+                </div>
               </div>
               <span
                 style="display: table; clear: both;"

--- a/app/containers/TeamDetails/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/TeamDetails/tests/__snapshots__/index.test.js.snap
@@ -34,8 +34,7 @@ exports[`<TeamDetails /> Should render and match the snapshot 1`] = `
 .c3 {
   width: auto;
   height: auto;
-  margin-bottom: 2px;
-  margin-right: 8px;
+  margin-block-end: 2px;
 }
 
 .c4 {
@@ -140,6 +139,7 @@ exports[`<TeamDetails /> Should render and match the snapshot 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  gap: 8px;
 }
 
 .c11 {

--- a/app/containers/UserDetails/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/UserDetails/tests/__snapshots__/index.test.js.snap
@@ -224,8 +224,7 @@ exports[`<UserDetails /> Should render and match the snapshot 1`] = `
 .c3 {
   width: auto;
   height: auto;
-  margin-bottom: 2px;
-  margin-right: 8px;
+  margin-block-end: 2px;
 }
 
 .c37 {
@@ -416,6 +415,7 @@ exports[`<UserDetails /> Should render and match the snapshot 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  gap: 8px;
 }
 
 .c5 {

--- a/app/global/reducers/globalState/selectors.js
+++ b/app/global/reducers/globalState/selectors.js
@@ -1,4 +1,11 @@
 import { createSelector } from 'reselect';
+import { getLangDir } from 'rtl-detect';
+
+import { DEFAULT_LOCALE, isAppLanguageSupported } from 'i18n';
+
+import { makeSelectInterventionLanguageCode } from 'global/reducers/intervention';
+import { makeSelectUserSessionLanguageCode } from 'containers/AnswerSessionPage/selectors';
+
 import { initialState } from './reducer';
 
 /**
@@ -37,3 +44,27 @@ export const makeSelectFileDownloadLoading = () =>
 
 export const makeSelectNavbarHeight = () =>
   createSelector(selectGlobalStateDomain, ({ navbarHeight }) => navbarHeight);
+
+export const makeSelectInterventionElementsLanguageCode = () =>
+  createSelector(
+    makeSelectInterventionLanguageCode(),
+    makeSelectUserSessionLanguageCode(),
+    (interventionLanguageCode, userSessionLanguageCode) =>
+      interventionLanguageCode ?? userSessionLanguageCode,
+  );
+
+// Hardcoded/fixed UI elements, e.g. back, skip and continue buttons
+export const makeSelectInterventionFixedElementsDirection = () =>
+  createSelector(makeSelectInterventionElementsLanguageCode(), (languageCode) =>
+    getLangDir(
+      languageCode && isAppLanguageSupported(languageCode)
+        ? languageCode
+        : DEFAULT_LOCALE,
+    ),
+  );
+
+// Defined the by researcher, e.g. question title and subtitle, answers' labels
+export const makeSelectInterventionDynamicElementsDirection = () =>
+  createSelector(makeSelectInterventionElementsLanguageCode(), (languageCode) =>
+    getLangDir(languageCode ?? DEFAULT_LOCALE),
+  );

--- a/app/global/reducers/intervention/selectors.js
+++ b/app/global/reducers/intervention/selectors.js
@@ -1,4 +1,7 @@
 import { createSelector } from 'reselect';
+import { getLangDir } from 'rtl-detect';
+
+import { DEFAULT_LOCALE, isAppLanguageSupported } from 'i18n';
 
 import { canEdit } from 'models/Status/statusPermissions';
 
@@ -174,4 +177,20 @@ export const makeSelectInterventionLanguageCode = () =>
   createSelector(
     selectIntervention,
     (substate) => substate.intervention?.languageCode,
+  );
+
+// e.g. back, skip and continue buttons
+export const makeSelectInterventionFixedElementsDirection = () =>
+  createSelector(makeSelectInterventionLanguageCode(), (languageCode) =>
+    getLangDir(
+      languageCode && isAppLanguageSupported(languageCode)
+        ? languageCode
+        : DEFAULT_LOCALE,
+    ),
+  );
+
+// e.g. question title and subtitle, answers' labels
+export const makeSelectInterventionDynamicElementsDirection = () =>
+  createSelector(makeSelectInterventionLanguageCode(), (languageCode) =>
+    getLangDir(languageCode ?? DEFAULT_LOCALE),
   );

--- a/app/global/reducers/intervention/selectors.js
+++ b/app/global/reducers/intervention/selectors.js
@@ -7,6 +7,8 @@ import { canEdit } from 'models/Status/statusPermissions';
 
 import { makeSelectIsAdmin, makeSelectUserId } from 'global/reducers/auth';
 
+import { makeSelectUserSessionLanguageCode } from 'containers/AnswerSessionPage/selectors';
+
 import { initialState } from './reducer';
 
 export const selectIntervention = (state) => state.intervention || initialState;
@@ -176,7 +178,9 @@ export const makeSelectPredefinedParticipantById = (id) =>
 export const makeSelectInterventionLanguageCode = () =>
   createSelector(
     selectIntervention,
-    (substate) => substate.intervention?.languageCode,
+    makeSelectUserSessionLanguageCode(),
+    ({ intervention }, userSessionLanguageCode) =>
+      intervention?.languageCode ?? userSessionLanguageCode,
   );
 
 // e.g. back, skip and continue buttons

--- a/app/global/reducers/intervention/selectors.js
+++ b/app/global/reducers/intervention/selectors.js
@@ -1,13 +1,7 @@
 import { createSelector } from 'reselect';
-import { getLangDir } from 'rtl-detect';
-
-import { DEFAULT_LOCALE, isAppLanguageSupported } from 'i18n';
-
 import { canEdit } from 'models/Status/statusPermissions';
 
 import { makeSelectIsAdmin, makeSelectUserId } from 'global/reducers/auth';
-
-import { makeSelectUserSessionLanguageCode } from 'containers/AnswerSessionPage/selectors';
 
 import { initialState } from './reducer';
 
@@ -178,23 +172,5 @@ export const makeSelectPredefinedParticipantById = (id) =>
 export const makeSelectInterventionLanguageCode = () =>
   createSelector(
     selectIntervention,
-    makeSelectUserSessionLanguageCode(),
-    ({ intervention }, userSessionLanguageCode) =>
-      intervention?.languageCode ?? userSessionLanguageCode,
-  );
-
-// e.g. back, skip and continue buttons
-export const makeSelectInterventionFixedElementsDirection = () =>
-  createSelector(makeSelectInterventionLanguageCode(), (languageCode) =>
-    getLangDir(
-      languageCode && isAppLanguageSupported(languageCode)
-        ? languageCode
-        : DEFAULT_LOCALE,
-    ),
-  );
-
-// e.g. question title and subtitle, answers' labels
-export const makeSelectInterventionDynamicElementsDirection = () =>
-  createSelector(makeSelectInterventionLanguageCode(), (languageCode) =>
-    getLangDir(languageCode ?? DEFAULT_LOCALE),
+    ({ intervention }) => intervention?.languageCode,
   );

--- a/app/i18n.js
+++ b/app/i18n.js
@@ -39,7 +39,11 @@ const translationMessages = {
   ar: formatTranslationMessages('ar', arTranslationMessages),
 };
 
+const isAppLanguageSupported = (languageCode) =>
+  appLocales.includes(languageCode);
+
 exports.appLocales = appLocales;
 exports.formatTranslationMessages = formatTranslationMessages;
 exports.translationMessages = translationMessages;
 exports.DEFAULT_LOCALE = DEFAULT_LOCALE;
+exports.isAppLanguageSupported = isAppLanguageSupported;

--- a/app/index.html
+++ b/app/index.html
@@ -41,7 +41,7 @@
     window.micAccessTool = new MicAccessTool({
       reportLink: 'https://msu.co1.qualtrics.com/jfe/form/SV_6S9MV7pPpoqFwTY',
       link: `${window.location.origin}/accessibility-statement`,
-      
+
     });
   }
 </script>


### PR DESCRIPTION
## Related tasks
- [CIAS-3697](https://htdevelopers.atlassian.net/browse/CIAS30-3697)

## What's new?
- If CIAS supports selected RTL intervention language then back, skip and continue buttons are mirrored on researcher edit view and on participant's view

## Tests
- [ ] Snapshot
- [ ] Logic
- [ ] Integration

# Screenshots
Eng:

<img width="723" alt="image" src="https://github.com/Michigan-State-University/cias-web/assets/86963976/3cdbdd61-b5b1-4272-afab-3a7c32ff0e6f">

Arabic (supported RTL language):
<img width="730" alt="image" src="https://github.com/Michigan-State-University/cias-web/assets/86963976/639cd956-7c26-4f22-886f-19fc2fb26622">

Hebrew (not supported RTL language):
<img width="723" alt="image" src="https://github.com/Michigan-State-University/cias-web/assets/86963976/21736e2c-e078-4e9e-a61d-d7305ad81c74">
