### PR TITLE
[CIAS30-3760] Display missing original texts in report template settings

### DIFF
--- a/app/containers/Sessions/containers/ReportTemplatesPage/components/ReportTemplateDetails/ReportTemplateMainSettings.js
+++ b/app/containers/Sessions/containers/ReportTemplatesPage/components/ReportTemplateDetails/ReportTemplateMainSettings.js
@@ -48,6 +48,7 @@ import CopyModal from 'components/CopyModal';
 import { VIEWS } from 'components/CopyModal/Components';
 import Tooltip from 'components/Tooltip';
 import { LabelPosition, Switch } from 'components/Switch';
+import OriginalTextHover from 'components/OriginalTextHover';
 
 import { CardBox, Spacer } from '../../styled';
 import { ReportTemplatesContext } from '../../utils';
@@ -538,21 +539,30 @@ const ReportTemplateMainSettings = ({
                         </Row>
                         <Row style={{ marginBottom: 20 }}>
                           <Col>
-                            <Box bg={colors.linkWater} width="100%">
-                              <ApprovableInput
-                                disabled={!canEdit}
-                                type="multiline"
-                                richText
-                                value={
-                                  singleReportTemplate.coverLetterDescription
-                                }
-                                onCheck={onCoverLetterDescriptionChange}
-                                placeholder={formatMessage(
-                                  globalMessages.enterTextHereRichText,
-                                )}
-                                autoSize
-                              />
-                            </Box>
+                            <OriginalTextHover
+                              id={`report-template-${singleReportTemplate.id}-cover-letter-description`}
+                              text={
+                                singleReportTemplate.originalText
+                                  .coverLetterDescription
+                              }
+                              width="100%"
+                            >
+                              <Box bg={colors.linkWater} width="100%">
+                                <ApprovableInput
+                                  disabled={!canEdit}
+                                  type="multiline"
+                                  richText
+                                  value={
+                                    singleReportTemplate.coverLetterDescription
+                                  }
+                                  onCheck={onCoverLetterDescriptionChange}
+                                  placeholder={formatMessage(
+                                    globalMessages.enterTextHereRichText,
+                                  )}
+                                  autoSize
+                                />
+                              </Box>
+                            </OriginalTextHover>
                           </Col>
                         </Row>
 
@@ -561,18 +571,27 @@ const ReportTemplateMainSettings = ({
                         </Row>
                         <Row style={{ marginBottom: 20 }}>
                           <Col>
-                            <Box bg={colors.linkWater} width="100%">
-                              <ApprovableInput
-                                disabled={!canEdit}
-                                mr={0}
-                                type="singleline"
-                                value={singleReportTemplate.coverLetterSender}
-                                onCheck={onCoverLetterSenderChange}
-                                placeholder={formatMessage(
-                                  globalMessages.enterTextHere,
-                                )}
-                              />
-                            </Box>
+                            <OriginalTextHover
+                              id={`report-template-${singleReportTemplate.id}-cover-letter-sender`}
+                              text={
+                                singleReportTemplate.originalText
+                                  .coverLetterSender
+                              }
+                              width="100%"
+                            >
+                              <Box bg={colors.linkWater} width="100%">
+                                <ApprovableInput
+                                  disabled={!canEdit}
+                                  mr={0}
+                                  type="singleline"
+                                  value={singleReportTemplate.coverLetterSender}
+                                  onCheck={onCoverLetterSenderChange}
+                                  placeholder={formatMessage(
+                                    globalMessages.enterTextHere,
+                                  )}
+                                />
+                              </Box>
+                            </OriginalTextHover>
                           </Col>
                         </Row>
                       </>
@@ -591,18 +610,24 @@ const ReportTemplateMainSettings = ({
                 </Row>
                 <Row style={{ marginBottom: 20 }}>
                   <Col>
-                    <Box bg={colors.linkWater} width="100%">
-                      <ApprovableInput
-                        disabled={!canEdit}
-                        mr={0}
-                        type="singleline"
-                        value={singleReportTemplate.name}
-                        onCheck={onNameChange}
-                        placeholder={formatMessage(
-                          messages.settingsNamePlaceholder,
-                        )}
-                      />
-                    </Box>
+                    <OriginalTextHover
+                      id={`report-template-${singleReportTemplate.id}-name`}
+                      text={singleReportTemplate.originalText.name}
+                      width="100%"
+                    >
+                      <Box bg={colors.linkWater} width="100%">
+                        <ApprovableInput
+                          disabled={!canEdit}
+                          mr={0}
+                          type="singleline"
+                          value={singleReportTemplate.name}
+                          onCheck={onNameChange}
+                          placeholder={formatMessage(
+                            messages.settingsNamePlaceholder,
+                          )}
+                        />
+                      </Box>
+                    </OriginalTextHover>
                   </Col>
                 </Row>
 

--- a/app/containers/Sessions/containers/ReportTemplatesPage/components/ReportTemplateDetails/ReportTemplatePreview.js
+++ b/app/containers/Sessions/containers/ReportTemplatesPage/components/ReportTemplateDetails/ReportTemplatePreview.js
@@ -15,6 +15,9 @@ import DashedButton from 'components/Button/DashedButton';
 import Img from 'components/Img';
 import { StyledInput } from 'components/Input/StyledInput';
 import { DndSortable } from 'components/DragAndDrop';
+import OriginalTextHover, {
+  OriginalTextIconPosition,
+} from 'components/OriginalTextHover';
 
 import TemplateSectionItem from './TemplateSectionItem';
 import { CardBox } from '../../styled';
@@ -85,20 +88,27 @@ const ReportTemplatePreview = () => {
               )}
               <Row style={{ marginBottom: 30 }}>
                 <Col>
-                  <StyledInput
-                    type="singleline"
-                    width="100%"
-                    placeholder={formatMessage(
-                      messages.reportHeaderPlaceholder,
-                    )}
-                    value={singleReportTemplate.summary ?? ''}
-                    onBlur={onSummaryChange}
-                    disabled={!canEdit}
-                    fontSize={32}
-                    maxWidth="none"
-                    fontWeight="bold"
-                    pl="0px"
-                  />
+                  <OriginalTextHover
+                    id={`report-template-${selectedReportId}-summary`}
+                    text={singleReportTemplate.originalText.summary}
+                    iconPosition={OriginalTextIconPosition.START}
+                    marginInlineStart={10}
+                  >
+                    <StyledInput
+                      type="singleline"
+                      width="100%"
+                      placeholder={formatMessage(
+                        messages.reportHeaderPlaceholder,
+                      )}
+                      value={singleReportTemplate.summary ?? ''}
+                      onBlur={onSummaryChange}
+                      disabled={!canEdit}
+                      fontSize={32}
+                      maxWidth="none"
+                      fontWeight="bold"
+                      pl="0px"
+                    />
+                  </OriginalTextHover>
                 </Col>
               </Row>
               <DndSortable

--- a/app/models/ReportTemplate/ReportTemplate.ts
+++ b/app/models/ReportTemplate/ReportTemplate.ts
@@ -32,6 +32,8 @@ export interface ReportTemplateVariant {
 export interface ReportTemplateOriginalText {
   name: string;
   summary: string;
+  coverLetterSender: string;
+  coverLetterDescription: string;
 }
 
 export enum CoverLetterLogoType {


### PR DESCRIPTION
## Related tasks
- [CIAS-3760](https://htdevelopers.atlassian.net/browse/CIAS30-3760)

## What's new?
- displat original texts for report template summary, name, fax sender and fax description

## Tests
- [ ] Snapshot
- [ ] Logic
- [ ] Integration

# Screenshots

<img width="615" alt="image" src="https://github.com/Michigan-State-University/cias-web/assets/86963976/a519564a-91a4-4bfd-b731-91a94ffef062">

