### PR TITLE
[CIAS30-3766] Show copy link form in email participants tab only

### DIFF
--- a/app/containers/InterventionDetailsPage/containers/ParticipantInviter/ParticipantListView.tsx
+++ b/app/containers/InterventionDetailsPage/containers/ParticipantInviter/ParticipantListView.tsx
@@ -101,15 +101,16 @@ export const ParticipantListView: FC<Props> = ({
           />
         </div>
       </Tabs>
-      {invitingPossible && (
-        <CopyLinkForm
-          isModularIntervention={isModularIntervention}
-          isReportingIntervention={isReportingIntervention}
-          interventionId={interventionId}
-          sessionOptions={sessionOptions}
-          healthClinicOptions={healthClinicOptions}
-        />
-      )}
+      {invitingPossible &&
+        activeTab === formatMessage(messages.emailParticipantsTab) && (
+          <CopyLinkForm
+            isModularIntervention={isModularIntervention}
+            isReportingIntervention={isReportingIntervention}
+            interventionId={interventionId}
+            sessionOptions={sessionOptions}
+            healthClinicOptions={healthClinicOptions}
+          />
+        )}
     </>
   );
 };


### PR DESCRIPTION
## Related tasks
- [CIAS-3766](https://htdevelopers.atlassian.net/browse/CIAS30-3766)

## What's new?
- as title

## Tests
- [ ] Snapshot
- [ ] Logic
- [ ] Integration

# Screenshots


https://github.com/Michigan-State-University/cias-web/assets/86963976/d9ec7279-6c42-4e76-ad7b-0f13d2a79f24


