### PR TITLE
[CIAS30-3809] Redirect logged in participants to user intervention pa…

### DIFF
--- a/app/containers/AnswerSessionPage/components/tests/__snapshots__/FinishScreen.test.js.snap
+++ b/app/containers/AnswerSessionPage/components/tests/__snapshots__/FinishScreen.test.js.snap
@@ -51,7 +51,7 @@ exports[`<FinishScreen /> Should render and match the snapshot 1`] = `
   >
     <a
       class="c1"
-      href="/"
+      href="/user_interventions/undefined"
     >
       <button
         class="c2"

--- a/app/containers/AnswerSessionPage/layouts/FinishScreenLayout.tsx
+++ b/app/containers/AnswerSessionPage/layouts/FinishScreenLayout.tsx
@@ -8,7 +8,6 @@ import { parametrizeRoutePath } from 'utils/router';
 
 import { InterventionSharedTo, InterventionType } from 'models/Intervention';
 import { FinishQuestionDTO } from 'models/Question';
-import { useRoleManager } from 'models/User/RolesManager';
 
 import { resetReducer as resetAuthReducer } from 'global/reducers/auth/actions';
 import { makeSelectInterventionFixedElementsDirection } from 'global/reducers/globalState';
@@ -34,7 +33,6 @@ type Props = {
 
 const FinishScreenLayout = ({ formatMessage, question }: Props) => {
   const isGuestUser = !LocalStorageService.getState();
-  const { isPredefinedParticipant } = useRoleManager();
 
   const dispatch = useDispatch();
   const userSession = useSelector(makeSelectUserSession());
@@ -141,12 +139,9 @@ const FinishScreenLayout = ({ formatMessage, question }: Props) => {
 
   const getGoToDashboardButtonLink = () => {
     if (isPreview) return '#';
-    if (isPredefinedParticipant) {
-      return parametrizeRoutePath(RoutePath.USER_INTERVENTION, {
-        userInterventionId,
-      });
-    }
-    return RoutePath.DASHBOARD;
+    return parametrizeRoutePath(RoutePath.USER_INTERVENTION, {
+      userInterventionId,
+    });
   };
 
   return (


### PR DESCRIPTION
…ge after finishing sequential session

## Related tasks
- [CIAS-3809](https://htdevelopers.atlassian.net/browse/CIAS30-3809)

## What's new?
- "Go to dashboard" button shown on finish screen for logged in participants in sequential interventions leads to a user intervention page instead of the main dashboard page

## Tests
- [ ] Snapshot
- [ ] Logic
- [ ] Integration

# Screenshots
N/A
