### PR TITLE
[CIAS30-3599] Show error messages from API in error toasts

### DIFF
--- a/app/global/reducers/dashboardSections/sagas/editDashboardSection.js
+++ b/app/global/reducers/dashboardSections/sagas/editDashboardSection.js
@@ -5,7 +5,7 @@ import { toast } from 'react-toastify';
 import { jsonApiToObject } from 'utils/jsonApiMapper';
 import objectToSnakeCase from 'utils/objectToSnakeCase';
 import { getObjectKeysWithoutIds } from 'utils/getObjectKeys';
-import { formatMessage } from 'utils/intlOutsideReact';
+import { formatApiErrorMessage } from 'utils/formatApiErrorMessage';
 
 import { EDIT_SECTION_REQUEST } from '../constants';
 import {
@@ -34,7 +34,7 @@ export function* editDashboardSection({
     const objectKeys = getObjectKeysWithoutIds(dashboardSection);
     yield call(
       toast.error,
-      formatMessage(messages.editSectionError, {
+      formatApiErrorMessage(error, messages.editSectionError, {
         properties: objectKeys.join(', '),
         propertiesCount: objectKeys.length,
       }),

--- a/app/global/reducers/organizations/sagas/editClinic.js
+++ b/app/global/reducers/organizations/sagas/editClinic.js
@@ -4,8 +4,8 @@ import { toast } from 'react-toastify';
 
 import { jsonApiToObject } from 'utils/jsonApiMapper';
 import objectKeysToSnakeCase from 'utils/objectToSnakeCase';
-import { formatMessage } from 'utils/intlOutsideReact';
 import { getObjectKeysWithoutIds } from 'utils/getObjectKeys';
+import { formatApiErrorMessage } from 'utils/formatApiErrorMessage';
 
 import { EDIT_CLINIC_REQUEST } from '../constants';
 import { editClinicFailure, editClinicSuccess } from '../actions';
@@ -30,7 +30,7 @@ export function* editClinic({ payload: { clinic } }) {
     const objectKeys = getObjectKeysWithoutIds(clinic);
     yield call(
       toast.error,
-      formatMessage(messages.editEntityError, {
+      formatApiErrorMessage(error, messages.editEntityError, {
         properties: objectKeys.join(', '),
         propertiesCount: objectKeys.length,
       }),

--- a/app/global/reducers/organizations/sagas/editHealthSystem.js
+++ b/app/global/reducers/organizations/sagas/editHealthSystem.js
@@ -4,8 +4,8 @@ import { toast } from 'react-toastify';
 
 import { jsonApiToObject } from 'utils/jsonApiMapper';
 import objectKeysToSnakeCase from 'utils/objectToSnakeCase';
-import { formatMessage } from 'utils/intlOutsideReact';
 import { getObjectKeysWithoutIds } from 'utils/getObjectKeys';
+import { formatApiErrorMessage } from 'utils/formatApiErrorMessage';
 
 import { editHealthSystemFailure, editHealthSystemSuccess } from '../actions';
 import { EDIT_HEALTH_SYSTEM_REQUEST } from '../constants';
@@ -28,7 +28,7 @@ export function* editHealthSystem({ payload: { healthSystem } }) {
     const objectKeys = getObjectKeysWithoutIds(healthSystem);
     yield call(
       toast.error,
-      formatMessage(messages.editEntityError, {
+      formatApiErrorMessage(error, messages.editEntityError, {
         properties: objectKeys.join(', '),
         propertiesCount: objectKeys.length,
       }),

--- a/app/global/reducers/organizations/sagas/editOrganization.js
+++ b/app/global/reducers/organizations/sagas/editOrganization.js
@@ -5,7 +5,7 @@ import { toast } from 'react-toastify';
 import { jsonApiToObject } from 'utils/jsonApiMapper';
 import objectKeysToSnakeCase from 'utils/objectToSnakeCase';
 import { getObjectKeysWithoutIds } from 'utils/getObjectKeys';
-import { formatMessage } from 'utils/intlOutsideReact';
+import { formatApiErrorMessage } from 'utils/formatApiErrorMessage';
 
 import { EDIT_ORGANIZATION_REQUEST } from '../constants';
 import { editOrganizationFailure, editOrganizationSuccess } from '../actions';
@@ -28,7 +28,7 @@ export function* editOrganization({ payload: { organization } }) {
     const objectKeys = getObjectKeysWithoutIds(organization);
     yield call(
       toast.error,
-      formatMessage(messages.editEntityError, {
+      formatApiErrorMessage(error, messages.editEntityError, {
         properties: objectKeys.join(', '),
         propertiesCount: objectKeys.length,
       }),

--- a/app/global/reducers/session/sagas/editSession.js
+++ b/app/global/reducers/session/sagas/editSession.js
@@ -1,14 +1,18 @@
 import { put, takeLatest, select, call } from 'redux-saga/effects';
 import axios from 'axios';
+import { toast } from 'react-toastify';
 
 import pickFields from 'utils/pickFields';
-import { makeSelectSessionById } from 'global/reducers/intervention';
 import { jsonApiToObject } from 'utils/jsonApiMapper';
+import { formatApiErrorMessage } from 'utils/formatApiErrorMessage';
+
+import { makeSelectSessionById } from 'global/reducers/intervention';
+
 import { EDIT_SESSION_REQUEST } from '../constants';
 
 import { editSessionSuccess, editSessionError } from '../actions';
-
 import { makeSelectSession } from '../selectors';
+import messages from '../messages';
 
 export function* editSession({ fields, payload: { sessionId } } = {}) {
   const session = sessionId
@@ -28,6 +32,10 @@ export function* editSession({ fields, payload: { sessionId } } = {}) {
 
     yield put(editSessionSuccess(jsonApiToObject(data, 'session')));
   } catch (error) {
+    yield call(
+      toast.error,
+      formatApiErrorMessage(error, messages.editSessionError),
+    );
     yield put(editSessionError(error));
   }
 }

--- a/app/utils/formatApiErrorMessage.ts
+++ b/app/utils/formatApiErrorMessage.ts
@@ -5,4 +5,7 @@ import { formatMessage } from './intlOutsideReact';
 export const formatApiErrorMessage = (
   error: any,
   defaultMessage: MessageDescriptor,
-) => error?.response?.data?.message ?? formatMessage(defaultMessage);
+  defaultMessageValues?: Parameters<typeof formatMessage>[1],
+) =>
+  error?.response?.data?.message ??
+  formatMessage(defaultMessage, defaultMessageValues);


### PR DESCRIPTION
## Related tasks
- [CIAS-3599](https://htdevelopers.atlassian.net/browse/CIAS30-3599)

## What's new?
1. Add a toast error message for using the same session variable name (list of session in the intervention - researcher) 

2. Adjust text error in the toast to be the same as it’s came from BE for:
- Health system name
- Organization name
- Clinic name
- Dashboard section name (Organization charts view) 

## Tests
- [ ] Snapshot
- [ ] Logic
- [ ] Integration

# Screenshots
N/A
