### PR TITLE
[CIAS30-3912] Use lang query param for detecting intervention language

### DIFF
--- a/app/containers/AnswerSessionPage/actions.js
+++ b/app/containers/AnswerSessionPage/actions.js
@@ -77,11 +77,17 @@ export const startSession = () => actionBuilder(START_SESSION, {});
 export const resetSession = (sessionId) =>
   actionBuilder(RESET_SESSION, { sessionId });
 
-export const redirectToPreview = (interventionId, sessionId, questionId) =>
+export const redirectToPreview = (
+  interventionId,
+  sessionId,
+  questionId,
+  languageCode,
+) =>
   actionBuilder(REDIRECT_TO_PREVIEW, {
     interventionId,
     sessionId,
     questionId,
+    languageCode,
   });
 
 export const changePreviewMode = (previewMode) =>

--- a/app/containers/AnswerSessionPage/index.js
+++ b/app/containers/AnswerSessionPage/index.js
@@ -26,6 +26,7 @@ import isNullOrUndefined from 'utils/isNullOrUndefined';
 import { DESKTOP_MODE, I_PHONE_8_PLUS_MODE } from 'utils/previewMode';
 import { CHARACTER_FIXED_POSITION_QUESTIONS } from 'utils/characterConstants';
 import LocalStorageService from 'utils/localStorageService';
+import useQuery from 'utils/useQuery';
 
 import {
   makeSelectAudioInstance,
@@ -51,7 +52,11 @@ import {
   chatWidgetReducerKey,
   setChatEnabled,
 } from 'global/reducers/chatWidget';
-import { RoutePath, REDIRECT_QUERY_KEY } from 'global/constants';
+import {
+  RoutePath,
+  REDIRECT_QUERY_KEY,
+  INTERVENTION_LANGUAGE_QUERY_KEY,
+} from 'global/constants';
 
 import { canPreview } from 'models/Status/statusPermissions';
 import { finishQuestion } from 'models/Session/QuestionTypes';
@@ -64,6 +69,7 @@ import {
   ANSWER_SESSION_PAGE_ID,
   ANSWER_SESSION_CONTAINER_ID,
 } from 'containers/App/constants';
+import { changeLocale as changeLocaleAction } from 'containers/AppLanguageProvider/actions';
 
 import {
   additionalBreakpoints,
@@ -228,6 +234,7 @@ export function AnswerSessionPage({
   fetchPreviousQuestion,
   fixedElementsDirection,
   dynamicElementsDirection,
+  changeLocale,
 }) {
   const { formatMessage } = useIntl();
   const history = useHistory();
@@ -311,6 +318,13 @@ export function AnswerSessionPage({
   const isCatMhSession = userSessionType === UserSessionType.CAT_MH;
 
   const location = useLocation();
+
+  const lang = useQuery(INTERVENTION_LANGUAGE_QUERY_KEY);
+  useEffect(() => {
+    if (lang) {
+      changeLocale(lang);
+    }
+  }, [lang]);
 
   const { sessionId, interventionId, index } = params;
 
@@ -996,6 +1010,7 @@ AnswerSessionPage.propTypes = {
   fetchPreviousQuestion: PropTypes.func,
   fixedElementsDirection: PropTypes.string,
   dynamicElementsDirection: PropTypes.string,
+  changeLocale: PropTypes.func,
 };
 
 const mapStateToProps = createStructuredSelector({
@@ -1025,6 +1040,7 @@ const mapDispatchToProps = {
   setLiveChatEnabled: setChatEnabled,
   saveQuickExitEvent: saveQuickExitEventRequest,
   fetchPreviousQuestion: fetchPreviousQuestionRequest,
+  changeLocale: changeLocaleAction,
 };
 
 const withConnect = connect(mapStateToProps, mapDispatchToProps);

--- a/app/containers/AnswerSessionPage/saga.js
+++ b/app/containers/AnswerSessionPage/saga.js
@@ -6,7 +6,7 @@ import merge from 'lodash/merge';
 
 import { AnswerType } from 'models/Answer';
 
-import { RoutePath } from 'global/constants';
+import { INTERVENTION_LANGUAGE_QUERY_KEY, RoutePath } from 'global/constants';
 
 import { mapQuestionToStateObject } from 'utils/mapResponseObjects';
 import { formatMessage } from 'utils/intlOutsideReact';
@@ -191,16 +191,20 @@ function* nextQuestion({ payload: { userSessionId, questionId } }) {
 }
 
 function* redirectToPreview({
-  payload: { interventionId, sessionId, questionId },
+  payload: { interventionId, sessionId, questionId, languageCode },
 }) {
   yield call(logInGuest, { payload: { sessionId } });
   yield call(
     window.open,
-    parametrizeRoutePath(RoutePath.PREVIEW_SESSION_FROM_INDEX, {
-      interventionId,
-      sessionId,
-      index: questionId,
-    }),
+    parametrizeRoutePath(
+      RoutePath.PREVIEW_SESSION_FROM_INDEX,
+      {
+        interventionId,
+        sessionId,
+        index: questionId,
+      },
+      { [INTERVENTION_LANGUAGE_QUERY_KEY]: languageCode },
+    ),
   );
 }
 

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -35,7 +35,11 @@ import {
   makeSelectUser,
   fetchSelfDetailsSaga,
 } from 'global/reducers/auth';
-import { RoutePath, WILDCARD_PATH } from 'global/constants';
+import {
+  INTERVENTION_LANGUAGE_QUERY_KEY,
+  RoutePath,
+  WILDCARD_PATH,
+} from 'global/constants';
 
 import AnswerSessionPage from 'containers/AnswerSessionPage/Loadable';
 import EditSessionPage from 'containers/Sessions/containers/EditSessionPage/Loadable';
@@ -148,7 +152,10 @@ export function App({ user, fetchSelfDetails }) {
   }, [user]);
 
   useEffect(() => {
-    document.documentElement.setAttribute('lang', locale);
+    document.documentElement.setAttribute(
+      INTERVENTION_LANGUAGE_QUERY_KEY,
+      locale,
+    );
     const accToolbarWidget = window.micAccessTool;
     if (accToolbarWidget) {
       document.getElementById(ACC_TOOLBAR_ROOT_ID).remove();

--- a/app/containers/InterventionDetailsPage/Header.js
+++ b/app/containers/InterventionDetailsPage/Header.js
@@ -35,6 +35,7 @@ const Header = ({
   canCurrentUserMakeChanges,
   editingPossible,
   name,
+  languageCode,
   editName,
   handleChangeStatus,
   interventionId,
@@ -133,6 +134,7 @@ const Header = ({
             <ParticipantsInviter
               interventionId={interventionId}
               interventionName={name}
+              interventionLanguageCode={languageCode}
               organizationId={organizationId}
               interventionStatus={status}
               interventionType={interventionType}
@@ -214,6 +216,7 @@ Header.propTypes = {
   canCurrentUserMakeChanges: PropTypes.bool,
   editingPossible: PropTypes.bool,
   name: PropTypes.string,
+  languageCode: PropTypes.string,
   editName: PropTypes.func,
   handleChangeStatus: PropTypes.func,
   interventionId: PropTypes.string,

--- a/app/containers/InterventionDetailsPage/containers/ParticipantInviter/CopyLinkForm.tsx
+++ b/app/containers/InterventionDetailsPage/containers/ParticipantInviter/CopyLinkForm.tsx
@@ -19,6 +19,7 @@ export type Props = {
   isModularIntervention: boolean;
   isReportingIntervention: boolean;
   interventionId: string;
+  interventionLanguageCode: string;
   sessionOptions: SelectOption<string>[];
   healthClinicOptions: SelectOption<string>[];
 };
@@ -27,6 +28,7 @@ export const CopyLinkForm: FC<Props> = ({
   isModularIntervention,
   isReportingIntervention,
   interventionId,
+  interventionLanguageCode,
   sessionOptions,
   healthClinicOptions,
 }) => {
@@ -93,6 +95,7 @@ export const CopyLinkForm: FC<Props> = ({
                 interventionId,
                 values.sessionOption?.value,
                 values.healthClinicOption?.value,
+                interventionLanguageCode,
               )}
               icon={share}
               iconAlt={formatMessage(messages.copyLinkIconAlt)}

--- a/app/containers/InterventionDetailsPage/containers/ParticipantInviter/InviteParticipantsModal.tsx
+++ b/app/containers/InterventionDetailsPage/containers/ParticipantInviter/InviteParticipantsModal.tsx
@@ -20,6 +20,7 @@ import { InviteParticipantsModalContent } from './InviteParticipantsModalContent
 export type Props = {
   interventionId: string;
   interventionName: string;
+  interventionLanguageCode: string;
   organizationId: Nullable<string>;
   interventionStatus: InterventionStatus;
   interventionType: InterventionType;
@@ -31,6 +32,7 @@ export const InviteParticipantsModal: FC<Props> = ({
   onClose,
   interventionId,
   interventionName,
+  interventionLanguageCode,
   organizationId,
   interventionType,
   interventionStatus,
@@ -74,6 +76,7 @@ export const InviteParticipantsModal: FC<Props> = ({
         setCurrentView={setCurrentView}
         interventionId={interventionId}
         interventionName={interventionName}
+        interventionLanguageCode={interventionLanguageCode}
         organizationId={organizationId}
         interventionType={interventionType}
         interventionStatus={interventionStatus}

--- a/app/containers/InterventionDetailsPage/containers/ParticipantInviter/InviteParticipantsModalContent.tsx
+++ b/app/containers/InterventionDetailsPage/containers/ParticipantInviter/InviteParticipantsModalContent.tsx
@@ -39,6 +39,7 @@ import { ManagePredefinedParticipantView } from './ManagePredefinedParticipantVi
 export type Props = {
   interventionId: string;
   interventionName: string;
+  interventionLanguageCode: string;
   organizationId: Nullable<string>;
   interventionStatus: InterventionStatus;
   interventionType: InterventionType;
@@ -50,6 +51,7 @@ export type Props = {
 export const InviteParticipantsModalContent: FC<Props> = ({
   interventionId,
   interventionName,
+  interventionLanguageCode,
   organizationId,
   interventionStatus,
   interventionType,
@@ -195,6 +197,7 @@ export const InviteParticipantsModalContent: FC<Props> = ({
               isReportingIntervention={isReportingIntervention}
               interventionId={interventionId}
               interventionName={interventionName}
+              interventionLanguageCode={interventionLanguageCode}
               invitingPossible={invitingPossible}
               copyingInvitationLinkPossible={copyingInvitationLinkPossible}
               creatingPredefinedParticipantsPossible={

--- a/app/containers/InterventionDetailsPage/containers/ParticipantInviter/ParticipantListView.tsx
+++ b/app/containers/InterventionDetailsPage/containers/ParticipantInviter/ParticipantListView.tsx
@@ -19,6 +19,7 @@ export type Props = {
   isReportingIntervention: boolean;
   interventionId: string;
   interventionName: string;
+  interventionLanguageCode: string;
   invitingPossible: boolean;
   copyingInvitationLinkPossible: boolean;
   creatingPredefinedParticipantsPossible: boolean;
@@ -38,6 +39,7 @@ export const ParticipantListView: FC<Props> = ({
   isReportingIntervention,
   interventionId,
   interventionName,
+  interventionLanguageCode,
   invitingPossible,
   copyingInvitationLinkPossible,
   creatingPredefinedParticipantsPossible,
@@ -109,6 +111,7 @@ export const ParticipantListView: FC<Props> = ({
             isModularIntervention={isModularIntervention}
             isReportingIntervention={isReportingIntervention}
             interventionId={interventionId}
+            interventionLanguageCode={interventionLanguageCode}
             sessionOptions={sessionOptions}
             healthClinicOptions={healthClinicOptions}
           />

--- a/app/containers/InterventionDetailsPage/containers/ParticipantInviter/ParticipantsInviter.tsx
+++ b/app/containers/InterventionDetailsPage/containers/ParticipantInviter/ParticipantsInviter.tsx
@@ -16,6 +16,7 @@ import { TEXT_BUTTON_PROPS } from './constants';
 export type Props = {
   interventionId: string;
   interventionName: string;
+  interventionLanguageCode: string;
   organizationId: Nullable<string>;
   interventionStatus: InterventionStatus;
   interventionType: InterventionType;

--- a/app/containers/InterventionDetailsPage/containers/ParticipantInviter/utils.ts
+++ b/app/containers/InterventionDetailsPage/containers/ParticipantInviter/utils.ts
@@ -74,12 +74,21 @@ export const createInviteUrl = (
 ): string => {
   let url;
 
+  const queryParams: Record<string, string> = {};
+  if (isReportingIntervention && healthClinicId) {
+    queryParams.cid = healthClinicId;
+  }
+  if (!isModularIntervention) {
+    queryParams.lang = interventionLanguageCode;
+  }
+
   if (isModularIntervention) {
     url = `${process.env.WEB_URL}${parametrizeRoutePath(
       RoutePath.INTERVENTION_INVITE,
       {
         interventionId,
       },
+      queryParams,
     )}`;
   } else {
     url = `${process.env.WEB_URL}${parametrizeRoutePath(
@@ -88,14 +97,8 @@ export const createInviteUrl = (
         interventionId,
         sessionId: sessionId ?? '',
       },
-      {
-        lang: interventionLanguageCode,
-      },
+      queryParams,
     )}`;
-  }
-
-  if (isReportingIntervention && healthClinicId) {
-    url = `${url}?cid=${healthClinicId}`;
   }
 
   return url;

--- a/app/containers/InterventionDetailsPage/containers/ParticipantInviter/utils.ts
+++ b/app/containers/InterventionDetailsPage/containers/ParticipantInviter/utils.ts
@@ -70,6 +70,7 @@ export const createInviteUrl = (
   interventionId: string,
   sessionId: Nullable<string>,
   healthClinicId: Nullable<string>,
+  interventionLanguageCode: string,
 ): string => {
   let url;
 
@@ -81,13 +82,16 @@ export const createInviteUrl = (
       },
     )}`;
   } else {
+    const queryParams = new URLSearchParams({
+      lang: interventionLanguageCode,
+    });
     url = `${process.env.WEB_URL}${parametrizeRoutePath(
       RoutePath.ANSWER_SESSION,
       {
         interventionId,
         sessionId: sessionId ?? '',
       },
-    )}`;
+    )}?${queryParams}`;
   }
 
   if (isReportingIntervention && healthClinicId) {

--- a/app/containers/InterventionDetailsPage/containers/ParticipantInviter/utils.ts
+++ b/app/containers/InterventionDetailsPage/containers/ParticipantInviter/utils.ts
@@ -82,16 +82,16 @@ export const createInviteUrl = (
       },
     )}`;
   } else {
-    const queryParams = new URLSearchParams({
-      lang: interventionLanguageCode,
-    });
     url = `${process.env.WEB_URL}${parametrizeRoutePath(
       RoutePath.ANSWER_SESSION,
       {
         interventionId,
         sessionId: sessionId ?? '',
       },
-    )}?${queryParams}`;
+      {
+        lang: interventionLanguageCode,
+      },
+    )}`;
   }
 
   if (isReportingIntervention && healthClinicId) {

--- a/app/containers/InterventionDetailsPage/index.js
+++ b/app/containers/InterventionDetailsPage/index.js
@@ -144,6 +144,7 @@ export function InterventionDetailsPage({
   const {
     sessions,
     name,
+    languageCode,
     id,
     status,
     csv,
@@ -538,6 +539,7 @@ export function InterventionDetailsPage({
 
             <Header
               name={name}
+              languageCode={languageCode}
               interventionId={interventionId}
               canCurrentUserMakeChanges={canCurrentUserMakeChanges}
               editingPossible={editingPossible}

--- a/app/containers/Navbar/components/InterventionsNavbar.js
+++ b/app/containers/Navbar/components/InterventionsNavbar.js
@@ -46,6 +46,7 @@ import { redirectToPreview } from 'containers/AnswerSessionPage/actions';
 import {
   makeSelectCanCurrentUserAccessParticipantsData,
   makeSelectEditingPossible,
+  makeSelectInterventionLanguageCode,
   makeSelectInterventionStatus,
 } from 'global/reducers/intervention';
 import { canPreview } from 'models/Status/statusPermissions';
@@ -102,6 +103,7 @@ const InterventionNavbar = ({
   generatedReportsCount,
   canAccessParticipantsData,
   editingPossible,
+  interventionLanguageCode,
 }) => {
   const { interventionId, sessionId } = params;
 
@@ -147,7 +149,12 @@ const InterventionNavbar = ({
     textLoaders;
 
   const handleRedirect = () =>
-    redirectToPreviewAction(interventionId, sessionId, selectedQuestion);
+    redirectToPreviewAction(
+      interventionId,
+      sessionId,
+      selectedQuestion,
+      interventionLanguageCode,
+    );
 
   return (
     <Row align="center" justify="between" width="100%" mr={35}>
@@ -350,6 +357,7 @@ InterventionNavbar.propTypes = {
   generatedReportsCount: PropTypes.number,
   canAccessParticipantsData: PropTypes.bool,
   editingPossible: PropTypes.bool,
+  interventionLanguageCode: PropTypes.string,
 };
 
 const mapStateToProps = createStructuredSelector({
@@ -365,6 +373,7 @@ const mapStateToProps = createStructuredSelector({
   generatedReportsCount: makeSelectReportsSize(),
   canAccessParticipantsData: makeSelectCanCurrentUserAccessParticipantsData(),
   editingPossible: makeSelectEditingPossible(),
+  interventionLanguageCode: makeSelectInterventionLanguageCode(),
 });
 
 const mapDispatchToProps = {

--- a/app/containers/RegisterPage/index.js
+++ b/app/containers/RegisterPage/index.js
@@ -52,6 +52,7 @@ import {
   registerFromInvitationRequest,
   clearErrors as clearErrorsAction,
 } from './actions';
+import { parseQueryToSingleValue } from './utils';
 
 const passwordLength = 8;
 
@@ -106,6 +107,7 @@ export function RegisterPage({
     intervention_id: interventionId,
     session_id: sessionId,
     cid,
+    lang,
   } = queryString.parse(location.search, { decode: false });
   const isInvite = Boolean(invitationToken) && Boolean(email);
 
@@ -132,36 +134,56 @@ export function RegisterPage({
     [interventionId, sessionId, error],
   );
 
+  const parsedLang = useMemo(() => parseQueryToSingleValue(lang), [lang]);
+  const parsedCid = useMemo(() => parseQueryToSingleValue(cid), [cid]);
+
   useEffect(() => {
     const shouldRedirect = success && isInvite && !loading;
 
     if (shouldRedirect) {
       let redirectPath;
 
+      const queryParams = {};
+      if (parsedCid) queryParams.cid = parsedCid;
+      if (parsedLang) queryParams.lang = parsedLang;
+
       if (shouldRedirectToIntervention) {
-        redirectPath = parametrizeRoutePath(RoutePath.INTERVENTION_INVITE, {
-          interventionId,
-        });
+        redirectPath = parametrizeRoutePath(
+          RoutePath.INTERVENTION_INVITE,
+          {
+            interventionId,
+          },
+          queryParams,
+        );
       }
 
       if (shouldRedirectToSession) {
-        redirectPath = parametrizeRoutePath(RoutePath.ANSWER_SESSION, {
-          interventionId,
-          sessionId,
-        });
+        redirectPath = parametrizeRoutePath(
+          RoutePath.ANSWER_SESSION,
+          {
+            interventionId,
+            sessionId,
+          },
+          queryParams,
+        );
       }
 
       if (!redirectPath) {
         redirectPath = RoutePath.DASHBOARD;
       }
 
-      if (cid) {
-        redirectPath += `?cid=${cid}`;
-      }
-
       history.replace(redirectPath);
     }
-  }, [success, loading, isInvite, interventionId, sessionId, cid, error]);
+  }, [
+    success,
+    loading,
+    isInvite,
+    interventionId,
+    sessionId,
+    parsedCid,
+    parsedLang,
+    error,
+  ]);
 
   return (
     <>

--- a/app/containers/RegisterPage/utils.ts
+++ b/app/containers/RegisterPage/utils.ts
@@ -1,0 +1,7 @@
+export const parseQueryToSingleValue = (query: string | string[] | null) => {
+  if (Array.isArray(query)) {
+    return query[0];
+  }
+
+  return query;
+};

--- a/app/global/constants/router.ts
+++ b/app/global/constants/router.ts
@@ -1,4 +1,5 @@
 export const REDIRECT_QUERY_KEY = 'redirect_to';
+export const INTERVENTION_LANGUAGE_QUERY_KEY = 'lang';
 
 export enum RoutePath {
   DASHBOARD = '/',

--- a/app/global/reducers/auth/types.ts
+++ b/app/global/reducers/auth/types.ts
@@ -9,6 +9,7 @@ export type RedirectData = {
   sessionId: Nullable<string>;
   healthClinicId: Nullable<string>;
   multipleFillSessionAvailable: boolean;
+  lang: string;
 };
 
 export type RedirectDataDTO = CamelToSnake<RedirectData>;

--- a/app/global/reducers/auth/utils.ts
+++ b/app/global/reducers/auth/utils.ts
@@ -18,6 +18,7 @@ export const getPredefinedParticipantRedirectPath = (
     sessionId,
     healthClinicId,
     multipleFillSessionAvailable,
+    lang,
   } = objectToCamelCase(redirectDataDTO);
 
   if (sessionId) {
@@ -27,7 +28,9 @@ export const getPredefinedParticipantRedirectPath = (
       sessionId,
     });
 
-    const queryParams = new URLSearchParams();
+    const queryParams = new URLSearchParams({
+      lang,
+    });
     if (healthClinicId) {
       queryParams.append('cid', healthClinicId);
     }
@@ -65,9 +68,10 @@ export const getShortLinkRedirectPath = (
     sessionId,
     healthClinicId,
     multipleFillSessionAvailable,
+    lang,
   } = objectToCamelCase(redirectDataDTO);
 
-  const queryParams = new URLSearchParams();
+  const queryParams = new URLSearchParams({ lang });
   if (healthClinicId) {
     queryParams.append('cid', healthClinicId);
   }

--- a/app/global/reducers/globalState/selectors.js
+++ b/app/global/reducers/globalState/selectors.js
@@ -1,10 +1,11 @@
 import { createSelector } from 'reselect';
 import { getLangDir } from 'rtl-detect';
 
-import { DEFAULT_LOCALE, isAppLanguageSupported } from 'i18n';
+import { isAppLanguageSupported } from 'i18n';
 
 import { makeSelectInterventionLanguageCode } from 'global/reducers/intervention';
 import { makeSelectUserSessionLanguageCode } from 'containers/AnswerSessionPage/selectors';
+import { makeSelectLocale } from 'containers/AppLanguageProvider';
 
 import { initialState } from './reducer';
 
@@ -55,16 +56,21 @@ export const makeSelectInterventionElementsLanguageCode = () =>
 
 // Hardcoded/fixed UI elements, e.g. back, skip and continue buttons
 export const makeSelectInterventionFixedElementsDirection = () =>
-  createSelector(makeSelectInterventionElementsLanguageCode(), (languageCode) =>
-    getLangDir(
-      languageCode && isAppLanguageSupported(languageCode)
-        ? languageCode
-        : DEFAULT_LOCALE,
-    ),
+  createSelector(
+    makeSelectInterventionElementsLanguageCode(),
+    makeSelectLocale(),
+    (languageCode, appLocale) =>
+      getLangDir(
+        languageCode && isAppLanguageSupported(languageCode)
+          ? languageCode
+          : appLocale,
+      ),
   );
 
 // Defined the by researcher, e.g. question title and subtitle, answers' labels
 export const makeSelectInterventionDynamicElementsDirection = () =>
-  createSelector(makeSelectInterventionElementsLanguageCode(), (languageCode) =>
-    getLangDir(languageCode ?? DEFAULT_LOCALE),
+  createSelector(
+    makeSelectInterventionElementsLanguageCode(),
+    makeSelectLocale(),
+    (languageCode, appLocale) => getLangDir(languageCode ?? appLocale),
   );

--- a/app/utils/router/parametrizeRoutePath.ts
+++ b/app/utils/router/parametrizeRoutePath.ts
@@ -2,11 +2,18 @@ import { RoutePath } from 'global/constants';
 
 export const parametrizeRoutePath = (
   path: RoutePath,
-  params: Record<string, string>,
+  pathParams: Record<string, string>,
+  queryParams?: Record<string, string>,
 ) => {
   let parametrizedPath: string = path;
-  Object.entries(params).forEach(([param, value]) => {
+  Object.entries(pathParams).forEach(([param, value]) => {
     parametrizedPath = parametrizedPath.replace(`:${param}`, value);
   });
+
+  if (queryParams) {
+    const urlSearchParams = new URLSearchParams(queryParams);
+    return `${parametrizedPath}?${urlSearchParams}`;
+  }
+
   return parametrizedPath;
 };

--- a/app/utils/router/parametrizeRoutePath.ts
+++ b/app/utils/router/parametrizeRoutePath.ts
@@ -10,7 +10,7 @@ export const parametrizeRoutePath = (
     parametrizedPath = parametrizedPath.replace(`:${param}`, value);
   });
 
-  if (queryParams) {
+  if (queryParams && Object.keys(queryParams).length > 0) {
     const urlSearchParams = new URLSearchParams(queryParams);
     return `${parametrizedPath}?${urlSearchParams}`;
   }

--- a/app/utils/useQuery.ts
+++ b/app/utils/useQuery.ts
@@ -2,9 +2,9 @@ import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router';
 
 const useQuery = (name: string): Nullable<string> => {
-  const [query, setQuery] = useState<Nullable<string>>(null);
-
   const { search } = useLocation();
+  const initialQuery = new URLSearchParams(search).get(name);
+  const [query, setQuery] = useState<Nullable<string>>(initialQuery);
 
   useEffect(() => {
     const queries = new URLSearchParams(search);


### PR DESCRIPTION
## Related tasks
- [CIAS-3912](https://htdevelopers.atlassian.net/browse/CIAS30-3912)

## What's new?
- Append `lang` query param to fill session link when copying session link, opening preview and creating link after using short link and predefined participant link
- Use `lang` query param on AnswerSessionPage to change app language without waiting for user session to load

## Tests
- [ ] Snapshot
- [ ] Logic
- [ ] Integration

# Screenshots
N/A
